### PR TITLE
add mongodb training instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Every AWS zone needs a different AMI. Here's a list of AMI numbers for each zone
   * Leave off `-i` and the script will show you all available AMIs in this region.
   * Pick the AMI that has the most recent datetime
 
+* Percona-Training-MongoDB-20210107-AMI
+
+This is available in us-west-2 only by default. The ami is ami-0c2adaf7cfbf731ec
+
 ```
 $ ./start-instances.php -a ADD -r eu-west-1 -p TREK -c 6 -m db1
 You must set the AMI to use for the training instances.
@@ -54,7 +58,7 @@ Install ansible on your laptop.
 On Mac, easy with Homebrew:
 
 ```
-$ brew install ansible
+$ brew install ansible php@7.4
 ```
 
 ## Set Up Notes
@@ -70,6 +74,7 @@ There are multiple "machine types" which are used in different training courses:
   * app: This instance serves as sysbench, docker, and proxysql for the XtraDB Cluster Tutorial. Each student should get 1 app instance.
   * mysql1, mysql2, mysql3: These instances are used in the XtraDB Cluster Tutorial. Each student should get 1 of each of these.
   * node1: This instance is used in the PXC K8S Operator tutorial. Each student should receive 1 of these.*
+  * mongodb: This instance has the Percona Server for MongoDB packages. Each student should receive 1 of these for the MongoDB training.
 
 ## Set Up Instances
 

--- a/hosts.yml
+++ b/hosts.yml
@@ -195,3 +195,19 @@
       FLUSH BINARY LOGS;
       RESET MASTER;"
     when: (gr == "Y" and 'mysql3' in inventory_hostname)
+
+# For MongoDB exercises
+- hosts: mongodb
+  gather_facts: no
+  tasks:
+
+  - name: Stop default MongoDB instance
+    service:
+      name: mongod
+      state: stopped
+      enabled: false
+
+  - name: Delete default MongoDB directory
+    file:
+      path: "/var/lib/mongo/"
+      state: absent

--- a/packer/README.md
+++ b/packer/README.md
@@ -1,0 +1,22 @@
+# How to generate a new AMI using packer
+
+* Packer is a tool from Hasicorp that makes creating AMI very easy. You just write some bash, makee a config and Packer does the rest.
+* percona-training-ami.json is the Packer config
+* This specifies the base AMI (CentOS 7 in this case), which regions you want yours in, name, volume sizes, etc.
+
+* Look at the section “provisioners” within the packer config. The provisioners are executed in order. the last two, base.sh and percona-training-setup.sh do most of the setup.
+* Each time we need a new ami we need to create a new Packer config and then create a ‘percona-training-setup.sh’
+
+* The idea with Packer is to create a base AMI. For example, with MySQL, the AMI is a single MySQL install with some dummy data. 
+* We would launch X ec2 instances of that ami for a class. Then, run an ansible script against those instances to do any specific setup depending on the class. If it’s a PXC class, then Ansible will setup M/SS replication. If it’s a DBA101 class, then ansible will erase everything from each student’s 2nd machine. etc. etc.
+
+* It depends on what you want to do in the labs. Do you want them to install mongo from scrratch? Then you may not need an AMI at all, and we can just use the base CentOS AMI. Do you want mongo installed but not configured? Maybe an AMI to have mongo and utils installed with dummy data already on disk.
+
+1. Install awscli and configure keys with `aws configure`
+
+2. Prepare create percona-training-ami-NNN.json
+
+3. Prepare create percona-training-setup-NNN.sh
+
+4. Run `packer build percona-training-ami-NNN.json`
+

--- a/packer/percona-training-ami-mongo.json
+++ b/packer/percona-training-ami-mongo.json
@@ -1,0 +1,47 @@
+{
+	"builders": [{
+		"type": "amazon-ebs",
+		"region": "us-west-2",
+		"ami_regions": ["us-west-2"],
+		"source_ami": "ami-0a248ce88bcc7bd23",
+		"vpc_id": "vpc-0a4028f1c54b4bcf4",
+		"subnet_id": "subnet-094292b1d75a3b882",
+		"instance_type": "t2.large",
+		"ssh_username": "centos",
+		"ssh_pty": "true",
+		"ami_name": "Percona-Training-MongoDB-{{isotime \"20060102\"}}-AMI",
+		"associate_public_ip_address": "true",
+		"tags": {
+			"Name": "Percona-Training-MongoDB-{{isotime \"20060102\"}}-AMI"
+		},
+		"ami_block_device_mappings": [{
+			"device_name": "/dev/sda1",
+			"delete_on_termination": true,
+			"volume_size": 100,
+			"volume_type": "gp2"
+		}],
+		"launch_block_device_mappings": [{
+			"device_name": "/dev/sda1",
+			"delete_on_termination": true,
+			"volume_size": 100,
+			"volume_type": "gp2"
+		}]
+	}],
+	"provisioners": [
+		{
+			"type": "file",
+			"source": "usr-local-bin.sh",
+			"destination": "/tmp/usr-local-bin.sh"
+		},
+		{
+			"type": "shell",
+			"script": "base.sh",
+			"execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E sh '{{ .Path }}'"
+		},
+		{
+			"type": "shell",
+			"script": "percona-training-setup-mongo.sh",
+			"execute_command": "chmod +x {{ .Path }}; {{ .Vars }} sudo -E sh '{{ .Path }}'"
+		}
+	]
+}

--- a/packer/percona-training-setup-mongo.sh
+++ b/packer/percona-training-setup-mongo.sh
@@ -1,0 +1,33 @@
+#!/bin/bash	
+
+set -e  # Exit build if any command below fails/exits
+
+# 
+# percona-training-setup-mongo.sh
+#
+# A Packer shell provisioner script that creates an AMI
+# for use within Percona Training classrooms for basic
+# MongoDB operations.
+# 
+# This script performs the following operations:
+# - Installs Percona YUM repo
+# - Installs latest Percona Server for MongoDB 4.2
+# 
+
+echo "### Install Percona Repo"
+yum install -y http://repo.percona.com/yum/percona-release-latest.noarch.rpm
+percona-release setup -y psmdb42
+
+echo "### Install Latest Percona Server for MongoDB 4.2"
+yum install -y \
+	percona-server-mongodb.x86_64 
+
+echo "### Creating dbpath..."
+mkdir -p /mongodb/data
+
+echo "### Fix permissions..."
+chown -R mongod: /mongodb
+
+#----------------------------------------------
+echo "### Finished percona-training-setup.sh provisioning"
+sync && sleep 10 && sync

--- a/start-instances.php
+++ b/start-instances.php
@@ -4,7 +4,7 @@
 include 'config.php';
 
 $actions      = array('ADD', 'DROP', 'GENHOSTS', 'GENPUBHOSTS', 'GETANSIBLEHOSTS', 'GETCSV', 'GETSSHCONFIG', 'SYNCDYNAMO');
-$machineTypes = array('db1', 'db2', 'scoreboard', 'app', 'pmm', 'mysql1', 'mysql2', 'mysql3', 'pxc', 'gr', 'node1', 'node2', 'node3', 'node4');
+$machineTypes = array('db1', 'db2', 'scoreboard', 'app', 'pmm', 'mysql1', 'mysql2', 'mysql3', 'pxc', 'gr', 'node1', 'node2', 'node3', 'node4', 'mongodb');
 
 const DEBUG = false;
 


### PR DESCRIPTION
Creates a new mongodb type instance that is based on the Centos 7 ami including a fresh install of PSMDB 4.2 packages. Meant to be used with exercises from https://github.com/percona/training-material/tree/update_mongodb