### PR TITLE
fix k8s

### DIFF
--- a/roles/minikube/files/minikube-config.json
+++ b/roles/minikube/files/minikube-config.json
@@ -1,6 +1,6 @@
 {
     "cpus": 8,
-    "kubernetes-version": "v1.13.1",
+    "kubernetes-version": "v1.23.0",
     "memory": 24576,
     "vm-driver": "none"
 }

--- a/roles/minikube/tasks/main.yml
+++ b/roles/minikube/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - name: download kubectl
   get_url:
-    url: https://storage.googleapis.com/kubernetes-release/release/v1.16.0/bin/linux/amd64/kubectl
+    url: https://storage.googleapis.com/kubernetes-release/release/v1.23.0/bin/linux/amd64/kubectl
     dest: /usr/local/bin/kubectl
     mode: 0755
 
@@ -32,6 +32,7 @@
       - docker-ce
       - docker-ce-cli
       - containerd.io
+      - conntrack-tools
 
 - name: enable docker
   systemd:
@@ -54,6 +55,6 @@
     dest: /root/.minikube/config/config.json
 
 - name: start minikube
-  command: /usr/local/bin/minikube start
+  command: /usr/local/bin/minikube start --force
   args:
     creates: /root/.minikube/client.crt


### PR DESCRIPTION
This fixes the role `node` which is used to install Minikube for the operators training (both PXC and MongoDB)