### PR TITLE
add sysbench for pxc training

### DIFF
--- a/hosts.yml
+++ b/hosts.yml
@@ -187,6 +187,8 @@
 # For PXC/GR tutorial, on mysql1, create replication user to set up initial labs
 - hosts: mysql1
   gather_facts: no
+  roles:
+    - sysbench
   tasks:
 
   - name: Create repl user


### PR DESCRIPTION
we need sysbench on mysql1 host for the bfa exercise of PXC training