### PR TITLE
fix centos7 repos location

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -14,6 +14,9 @@
       ln -s /dev/null /etc/motd.d/cockpit
     fi
 
+- name: fix centos7 repo
+  shell: "sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*"
+
 - name: Update packages
   yum:
     state: latest


### PR DESCRIPTION
The Centos 7 repos have been archived so yum update is no longer working. This addresses it. 