### PR TITLE
fix compat with new AMI. Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 ## AMI List
 
 ```
-ami-0c2adaf7cfbf731ec - Centos 7 / MongoDB 4.4 (used also for the k8s MongoDB training)
+ami-0c2adaf7cfbf731ec - Centos 7 / MongoDB 4.4 (old)
 ami-0b02004363780dd42 - Centos 7 MySQL
 ami-0f5dcffa34c281c1a - Rocky 9 MySQL
-ami-0ad8bfd4b10994785 - Centos 9 MySQL / MongoDB 7.0
+ami-0ad8bfd4b10994785 - Centos 9 MySQL / MongoDB 7.0 / MongoDB Operator
 ```
 
 The MongoDB AMI is available only in `us-west-2` region at this time. 

--- a/roles/minikube/tasks/main.yml
+++ b/roles/minikube/tasks/main.yml
@@ -17,7 +17,7 @@
   yum_repository:
     name: Docker-CE
     description: Docker CE Stable
-    baseurl: https://download.docker.com/linux/centos/7/$basearch/stable
+    baseurl: https://download.docker.com/linux/centos/{{ ansible_facts['distribution_major_version'] }}/$basearch/stable
     gpgcheck: 1
     gpgkey:
       - https://download.docker.com/linux/centos/gpg


### PR DESCRIPTION
fixed a problem with Minikube installation on the new ami based on centos9. Also updated the README to reflect more clearly which AMIs to use. 