### PR TITLE
Add missing community health and project standard files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# GitHub Code Owners
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for all files
+* @utdrmac @igroene @michaelcoburn

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Description
+A clear and concise description of the changes made in this Pull Request.
+
+## Related Issue
+Fixes # (issue)
+
+## Checklist
+- [ ] I have read the [CONTRIBUTORS.md](CONTRIBUTORS.md) file.
+- [ ] My code follows the existing style and conventions.
+- [ ] I have added tests (if applicable) and verified the changes.
+- [ ] Documentation has been updated (if applicable).
+
+## Type of Change
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Maintenance/Refactoring
+- [ ] Documentation update

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing to Percona Training AWS Scripts
+
+First off, thank you for considering contributing to the Percona Training AWS Scripts! It's people like you that make these tools so much more useful for the community.
+
+## How to Contribute
+
+### Reporting Bugs
+If you find a bug, please create an issue on GitHub using the "Bug report" template. Include as much detail as possible to help us reproduce and fix it.
+
+### Suggesting Enhancements
+We welcome ideas for new features or improvements. Please use the "Feature request" template to describe your idea and its benefits.
+
+### Pull Requests
+We accept pull requests! To contribute code:
+1.  Fork the repository.
+2.  Create a new branch for your feature or fix.
+3.  Write your code and tests.
+4.  Run the linting and static analysis tools locally (`ansible-lint`, `phpstan`).
+5.  Submit a pull request to the `master` branch.
+
+## Code Style
+Please adhere to the existing code style in the repository. We use:
+- **PHP**: PHP 8.5+ with consistent indentation and PSR-like naming conventions.
+- **Ansible**: Roles and playbooks should be well-structured and linted.
+- **Packer**: Templates should be valid and follow best practices for AMIs.
+
+## Community Health
+Please refer to the [CONTRIBUTORS.md](CONTRIBUTORS.md) for a list of the primary maintainers and contributors.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,7 @@
+# Project Contributors
+
+The following individuals have made significant contributions to the Percona Training AWS Scripts project:
+
+- **Matthew Boehm** (@utdrmac) - Primary maintainer and developer.
+- **Ivan Groenewold** (@igroene) - Developer and maintainer.
+- **Michael Coburn** (@michaelcoburn) - Developer.


### PR DESCRIPTION
This PR extracts the community health files from PR #31 to improve transparency and maintainability.

### Changes:
- Added `CONTRIBUTORS.md`: A list of the primary maintainers and contributors.
- Added `.github/CODEOWNERS`: Defines the individuals or teams responsible for the code.
- Added `.github/ISSUE_TEMPLATE/bug_report.md`: Standardized templates for reporting bugs.
- Added `.github/PULL_REQUEST_TEMPLATE.md`: Standardized template for PR submissions.
- Added `CONTRIBUTING.md`: Provides guidance on how to contribute to the project.

Closes #34