### PR TITLE
Comprehensive README overhaul based on project history

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,231 +1,165 @@
 # Percona Training AWS Scripts
 
-## AMI List
+Automated provisioning scripts and Ansible playbooks used to deploy ephemeral AWS environments for Percona's training classes.
 
-Always use the latest AMI in the region you are delivering from. Leave off `-i`, and the script will show you all available AMIs in this region:
+This repository provides tools for instructors to quickly launch, configure, and tear down realistic database environments (MySQL, MongoDB, PostgreSQL) for students.
 
-```
-Example:
+## Prerequisites
 
-$ ./start-instances.php -a ADD -r eu-west-1 -p TREK -c 6 -m db1
-You must set the AMI to use for the training instances.
-The following Percona-Training AMIs were found in the 'eu-west-1' region:
+To run these scripts, your local control machine requires:
+* **PHP 8.5+**
+* **Composer** (for PHP dependencies)
+* **Ansible Core**
+* **AWS CLI** (configured with proper credentials in `~/.aws/credentials`)
+* **Make**
 
-Name                           - AMI
-Percona-Training-20200321-AMI  - ami-0e8223fee4b885841
-Percona-Training-20200710-AMI  - ami-0b02004363780dd42
-...
-```
+### Installation
 
-## Installation
-
-### Packages required
-
-You need PHP 8.5+ and `composer` to run the scripts. Ansible is also required.
-
-On Mac, easy with Homebrew:
-
-```
-$ brew install php@8.5 ansible awscli composer
+**macOS (Homebrew):**
+```bash
+brew install php@8.5 ansible awscli composer make
 ```
 
-On Linux the following packages are required:
-
-```
-$ sudo apt-get install php8.5 php-xml php-mbstring ansible awscli composer
-```
-
-After you install composer, install all necessary PHP packages:
-
-```
-$ composer install
+**Linux (Ubuntu/Debian):**
+```bash
+sudo apt-get install php8.5 php-xml php-mbstring ansible awscli composer make
 ```
 
-This will create a `vendor/` directory, with all the 3rd party libraries needed.
-
-### AWS Credentials
-
-Make sure you have your `~/.aws/credentials` configured:
-
-```
-$ cat ~/.aws/credentials 
-[default]
-aws_access_key_id = ...
-aws_secret_access_key = ...
+**Linux (Rocky Linux/RHEL 9):**
+```bash
+sudo dnf install php php-xml php-mbstring ansible-core awscli composer make
 ```
 
-## Set Up Notes
-
-NOTE: `TREK` is used below as an example. Use a "short code" that represents your client during training. Examples: `DELL` if you were training Dell Co.
-
-### Machine Types
-
-There are multiple "machine types" which are used in different training courses:
-  * `db1`: Used for the 'Scaling and Optimization' course. Exercises in the various chapters can be executed on db1. The 'MyMovies' chapter is a team-building exercise. You would assign 2-3 students for each db1 instance. This instance is also used for 'Operations and Troubleshooting' when doing xtrabackup labs, and functions as the master all master/slave exercises.
-  * `db2`: This machine type is used as the slave instance for all all master/slave exercises.
-  * `scoreboard`: This is for the MyMovies competition. Ansible will handle 100% of the configuration. You simply need to open the page in your browser (port 8080) and display on projector/monitor for students to see.
-  * `app`: This instance serves as sysbench, docker, and proxysql for the XtraDB Cluster and Group Replication tutorials. Each student should get 1 app instance.
-  * `mysql1`, `mysql2`, `mysql3`: These instances are used in the XtraDB Cluster and Group Replication tutorials. Each student should get 1 of each of these.
-  * `node1`: This instance is used in the K8S Operator tutorials. Each student should receive 1 of these.
-  * `mongodb`: This instance has the Percona Server for MongoDB packages. Each student should receive 1 of these for the MongoDB training.
-
-There are 2 machine type aliases, `gr` and `pxc`, both are aliases which will deploy each of the 4 types: `app`, `mysql1`, `mysql2`, and `mysql3`
-
-## Set Up Instances
-
-### 1. Ensure DynamoDB table exists
-
-**NOTE**: You should not need to do this step every time. You can assume this table exists unless the scrips output errors.
-
-Make sure there is a DynamoDB table created on the `us-east-1` region called `percona_training_servers`. This is used to support the training backed but sometimes is deleted. If it is not there, create it with the following structure:
-
-* `Partition Key`: `teamTag` (String)
-* `Sort Key`: `teamID` (Number)
-
-### 2. Create a new VPC
-
-All instances need to run inside a VPC. The VPC will launch with a single subnet of 10.11.0.0/16 with outbound internet capabilities.
-
-```
-./setup-vpc.php -a ADD -r eu-west-1 -p TREK
+After installing the system packages, install the PHP dependencies:
+```bash
+composer install
 ```
 
-This will create a VPC in the `eu-west-1` region named `Percona-Training-TREK`. It will create all necessary security group rules for allowing SSH (22), HTTP (80), HTTP-SSL (443), and HTTP-ALT (8080).
+---
 
-### 3. Add/Start EC2 Instances
+## Setting Up a Training Environment
 
-Using the same suffix (TREK in this case) we can launch instances inside the above VPC:
+The standard workflow utilizes a `Makefile` that encapsulates VPC creation, instance launching, and Ansible provisioning into a single command. 
 
-```
-./start-instances.php -a ADD -r eu-west-1 -p TREK -c 6 -m db1 -i ami-9f10fbec
-```
+Environments are built based on **Class Slugs**. A slug represents the specific course being taught and automatically deploys the correct architecture (e.g., `db1`, `gr`, `pxc`).
 
-The above example will launch 6 instances of the db1 image in the VPC. They will be named `Percona-Training-TREK-db1-T[1-6]`.
+### 0. List Available AMIs
 
-If you need to launch other instance types, simply repeat the above command and change the `-m` parameter.
+Before launching, you can check which AMIs are available in your target region:
 
-### 3a. Launch multiple instance types
-
-You can launch multiple instance types at the same time. Separate each type with `,` or use the two aliases.
-
-```
--- Launch 4 complete setups for use in the PXC tutorial. A total of 16 EC2 instances will be created (4 teams, each with 4 servers).
-./start-instances.php -a ADD -r eu-west-1 -p TREK -c 4 -m pxc -i ami-014230ad6c3e10ec2
-
--- Launch 7 setups for Operations class, db1 and db2. This will launch 14 instances total (7 teams, each with 2 servers).
-./start-instances.php -a ADD -r us-west-2 -p TREK -c 7 -m db1,db2 -i ami-014230ad6c3e10ec2
+```bash
+make list-amis region=eu-west-1
 ```
 
-### 3b. Add More Instances
+### 1. Launch the Environment
 
-If you need to add more instances (i.e.: more teams, or more students) you can do so using the `-o` (offset) to make sure the numbers match up. `-c ` is the number of instances to add.
+Run the `make setup` command, providing the class slug, your client identifier, the number of student teams, and optionally the AWS region (defaults to `us-west-2`).
 
-```
-./start-instances.php -a ADD -r eu-west-1 -p TREK -c 1 -o 6 -m db1 -i ami-9f10fbec
-```
-
-In this example, the offset `-o` is 6. The next numbered instance will start at 7. The above command will launch 1 `-c 1` more instance named `Percona-Training-TREK-db1-T7`
-
-### 4. Generate `ansible_hosts` and configure hosts
-
-Once all machines are up and running, we can generate an `ansible_hosts` file, which we can use to provision the servers.
-
-```
-./start-instances.php -a GETANSIBLEHOSTS -r eu-west-1 -p TREK > ansible_hosts_trek
+```bash
+make setup class=mysql-dev client=TREK teams=14 region=eu-west-1
 ```
 
-There is only 1 ansible playbook: `hosts.yml`. This playbook contains tasks for all of the different machine types by adding/removing yum repos, configuring the */etc/hosts* file, installing necessary software packages, checking out git repos, and much more.
+*Note: All created resources (Instances, VPCs, Subnets) are automatically tagged with a `TrainingEndDate` set to 7 days from creation to ensure automated cleanup and cost control.*
 
-You can re-run this playbook as needed. That's the nice thing about ansible; it only changes what needs to be changed to set a specific state.
+### 2. Distribute Connection Details
 
-Ideally, though, you would create all of your machine types then run this playbook only once.
+Once setup is complete, generate the student connection summary:
 
-```
-# ansible-playbook -i ansible_hosts_trek hosts.yml
-```
-
-If you add additional servers and need to provision them, you need to repeat the `GETANSIBLEHOSTS` command, and also repeat the `ansible-playbook` command. But you can specify a single server to make ansible go faster:
-
-```
-# ansible-playbook -i ansible_hosts_trek hosts.yml --limit mysql1-T7    // Provision the mysql1-T7 server only
-
-# ansible-playbook -i ansible_hosts_trek hosts.yml --limit T7    // Provision all servers from Team 7
+```bash
+make summary client=TREK
 ```
 
-### 5. Teams and Connecting to Instances
+This will output a formatted block of text containing the S3 dashboard URL (which lists all instance IPs), the standard SSH user (`ec2-user` or `rocky`), and instructions for downloading the SSH keys. Share this output with your class.
 
-Load the following URL to your presentation screen, and/or share the URL within chat, substituting XXXX for your "prefix":
+### 3. Teardown
 
-http://percona-training.s3-website-us-east-1.amazonaws.com/?tag=XXXX
+After the class concludes, destroy all resources to stop AWS billing:
 
-This will display all servers created for each team, along with their public and private IP addresses.
-
-Have the students download the keys .zip file from the URL at the bottom of this page. Mac/Linux users must `chmod 600 Percona-Training.key`
-
-Next, assign teams. Just point at each student and say "You are team 1, you are team 2, etc".
-_Exception:_ For the MyMovies competition, assign 2 students per 1 team.
-
-Once the keys and teams are distributed, students can connect to instances.
-
-The SSH username is usually `ec2-user` but depending on the AMI it can be different (e.g. `centos`). There is **NO password**. Windows/Putty users can use the PPK file.
-
-### 6. Removing Instances
-
-After the training is done, you need to remove the instances and the VPC
-
-```
-./start-instances.php -a DROP -r eu-west-1 -i ami-9f80fbec -p TREK
+```bash
+make teardown client=TREK region=eu-west-1
 ```
 
-Unfortunately, you need to manually remove the VPC in the AWS web-console interface:
+---
 
-- Go to https://aws.amazon.com
-- Go to the region where you created the instances
-- Click `VPC`
-- Go to `Your VPCs`
-- Select the VPC (in the example named `Percona-Training-TREK`) and click `Delete VPC`. 
+## Supported Courses and Slugs
 
-This will delete all the VPCs, subnets, gateways...
+Use the following slugs with the `class=` parameter in your `make setup` command.
 
-## Alternate Setup
+### MySQL Courses
+| Course Title | Class Slug | Architecture Deployed |
+| :--- | :--- | :--- |
+| MySQL Training for Database Operations Specialists | `mysql-ops` | `db1` (Master), `db2` (Replica) |
+| MySQL Training for Developers | `mysql-dev` | `db1` |
+| DBA Hands-On (MySQL 101) | `mysql-101` | `db1` |
+| MySQL for Oracle DBA's | `mysql-oracle-dba` | `db1` |
+| ProxySQL Tutorial | `proxysql` | `db1` |
+| Percona Operator for MySQL based on PXC | `mysql-k8s` | `node1` (K8s node) |
+| Percona XtraDB Cluster Tutorial | `pxc` | `pxc` (3 nodes + 1 app) |
+| MySQL Group Replication 101 | `gr-101` | `gr` (3 nodes + 1 app) |
+| Percona Group Replication Tutorial | `gr` | `gr` (3 nodes + 1 app) |
 
-For the *Scaling and Optimization* class, the students might find it more beneficial to have their own instance on which to run the query tuning exercises. This is a bit more work for you, the instructor, but is easially managed thanks to the scripts above. Here is an example timeline for this setup:
+### MongoDB Courses
+| Course Title | Class Slug | Architecture Deployed |
+| :--- | :--- | :--- |
+| MongoDB Training for Database Operations Specialists | `mongo-ops` | `mongodb` |
+| MongoDB Training for Developers | `mongo-dev` | `mongodb` |
 
-* Day 0: Some time before day 1, you know only 14 students will be attending. Create 15 DB1 instances (one additional for instructor). This will be 14 teams, one student per team. Run ansible as normal.
-* Day 1 (Class): Distribute servers as normal. Assign each student to their own team. Do exercises as normal.
-* Day 1 (Hotel): Destroy all 15 instances. Create 7 DB1 instances for 7 teams, 2 students per team, and 1 scoreboard instance. Run ansible as normal.
-* Day 2 (Class): Re-distribute servers as IPs will change. Assign students, in pairs, to new teams. Run My-Movies exercise.
-* Day 2 (Hotel): Destroy everything. If your class is continuing with *Operations and Troubleshooting*, re-launch 15 DB1 and 15 DB2 instances. Run ansible as normal.
-* Day 3 (Class): Again, re-distribute servers. Run remainder of class/exercises as normal.
+### PostgreSQL Courses
+| Course Title | Class Slug | Architecture Deployed |
+| :--- | :--- | :--- |
+| PostgreSQL Training for Database Operations Specialists | `pg-ops` | `db1` |
+| PostgreSQL Training for Developers | `pg-dev` | `db1` |
+| PostgreSQL Tutorial | `pg-tutorial` | `db1` |
 
-## Tutorials/Exercises
+---
 
-Pages are live-generated. Source is under the `gh-pages` branch of https://github.com/percona/training-material
+## Technical Details
 
-* Source/Replica Tutorial (Exercises for MySQL Operations & Troubleshooting)
-* ProxySQL Tutorial
-* Mesosphere Tutorial
-* Percona XtraDB Cluster Tutorial
-* Orchestrator Tutorial
-* PostgreSQL Tutorial
-* PMM Tutorial
+The provisioning scripts and Ansible playbooks support the following software and configurations:
 
-## MyMovies Exercise
+*   **Operating Systems:** Ubuntu 22.04+, Debian 11+, Rocky Linux 9+.
+*   **Database Versions:** Percona Server for MySQL 8.0, 8.4; Percona Server for MongoDB 7.0; and PMM 3.x client support.
+*   **Security:** IPTables is disabled by default to simplify lab networking.
+*   **SSL:** All MySQL instances are configured with SSL (SHA256).
 
-* Launch 1 db1 instance for each team, and 1 [scoreboard](https://github.com/percona/training-mymovies/blob/master/scoreboard/README.md) that is shared.
-* Scoreboard will hit 3 different pages on all dbX instances 
-* Teams compete to who can get the app to perform better
-* Check app files under /var/www/html on each instance for the app's PHP code
-* The `mymovies` app runs on port 80 of each `db1` instance (httpd)
-* The `scoreboard` is a Nodejs app listening on port 8080 of the `scoreboard` server
-* [Solutions](https://github.com/percona/training-material/blob/master/slides/modules/my_movies/my_movies_solutions.md)
+---
 
-## Survey
+## Advanced Usage
 
-At the end of the training, share a survey with the participants
+For custom deployments or debugging, you can bypass the `Makefile` and use the underlying PHP scripts directly.
 
-1. Create a PDF of your slides. everything in 1 PDF.
-2. Upload PDF to Google Drive
-3. Create share “if have the link” of the PDF
-4. Clone the [survey](https://docs.google.com/forms/d/12GCDBdzwGrOaM-MA3lxJziPUtkL37mDGWVvn41aMlDw/edit), click Settings, Presentation, edit Confirmation message. Paste in URL of PDF.
+### VPC Management
+```bash
+./setup-vpc.php -a [ADD|DROP|LIST|REBUILD] -r [REGION] -p [CLIENT_SUFFIX]
+```
 
+### Instance Management
+```bash
+./start-instances.php -a ADD -r [REGION] -p [CLIENT_SUFFIX] -c [NUM_TEAMS] -m [MACHINE_TYPE] -i [AMI_ID]
+```
+
+*   If you omit `-i [AMI_ID]`, the script will output a list of available `Percona-Training` AMIs in that region.
+*   To launch multiple machine types simultaneously, separate them with commas: `-m db1,db2`.
+*   Use `-o [OFFSET]` to add additional teams without overlapping existing numbers.
+
+### CloudFormation Templates
+Older iterations of the training labs (PMM, some PXC/GR setups) utilized pure AWS CloudFormation. These templates are retained in the `cloudformations/` directory for legacy support and reference.
+
+---
+
+## DynamoDB Requirement
+
+The scripts rely on an AWS DynamoDB table to sync and list the generated IPs for the student dashboard.
+
+*   **Region:** Must be in `us-east-1` (hardcoded).
+*   **Table Name:** `percona_training_servers`
+*   **Partition Key:** `teamTag` (String)
+*   **Sort Key:** `teamID` (Number)
+
+*You generally do not need to manage this table. The scripts will create or update it automatically.*
+
+---
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on code style, linting, and submitting Pull Requests. See [CONTRIBUTORS.md](CONTRIBUTORS.md) for a list of project maintainers.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To run these scripts, your local control machine requires:
 * **PHP 8.5+**
 * **Composer** (for PHP dependencies)
 * **Ansible Core**
-* **AWS CLI** (configured with proper credentials in `~/.aws/credentials`)
+* **AWS CLI** (configured with valid credentials — see [AWS Credentials](#aws-credentials) below)
 * **Make**
 
 ### Installation
@@ -35,6 +35,16 @@ After installing the system packages, install the PHP dependencies:
 composer install
 ```
 
+### AWS Credentials
+
+The scripts use the **AWS SDK default credential provider chain**, so any standard configuration method works — there is no longer a requirement for a `~/.aws/credentials` file with a `default` profile. The SDK resolves credentials in the usual order:
+
+1. Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`).
+2. The shared config/credentials files (`~/.aws/credentials`, `~/.aws/config`), including named profiles via `AWS_PROFILE`.
+3. An IAM role attached to the EC2 instance or container (instance profile).
+
+The simplest setup is to run `aws configure` once, or export the environment variables for your session.
+
 ---
 
 ## Setting Up a Training Environment
@@ -42,6 +52,18 @@ composer install
 The standard workflow utilizes a `Makefile` that encapsulates VPC creation, instance launching, and Ansible provisioning into a single command. 
 
 Environments are built based on **Class Slugs**. A slug represents the specific course being taught and automatically deploys the correct architecture (e.g., `db1`, `gr`, `pxc`).
+
+### The Class Identifier (`client`)
+
+The `client=` value (e.g., `TREK`) is the **class identifier** — a short code that uniquely tags every resource for a single training delivery. Choose a short, memorable code that represents the client or engagement (e.g., `TREK`, `DELL`, `ACME`).
+
+This identifier is used throughout the workflow:
+
+* It names and tags all AWS resources (e.g., the VPC `Percona-Training-TREK`, instances `Percona-Training-TREK-db1-T1`).
+* It is stored as the `teamTag` partition key in the DynamoDB table (see [DynamoDB Requirement](#dynamodb-requirement)), which is how the scripts track the instances belonging to this class.
+* It is the `tag` used by the student dashboard URL: `http://percona-training.s3-website-us-east-1.amazonaws.com/?tag=TREK`.
+
+Use the **same** `client` value for every `make` command (`setup`, `summary`, `teardown`) in a given class so they all operate on the same set of resources.
 
 ### 0. List Available AMIs
 
@@ -69,7 +91,7 @@ Once setup is complete, generate the student connection summary:
 make summary client=TREK
 ```
 
-This will output a formatted block of text containing the S3 dashboard URL (which lists all instance IPs), the standard SSH user (`ec2-user` or `rocky`), and instructions for downloading the SSH keys. Share this output with your class.
+This will output a formatted block of text containing the S3 dashboard URL (which lists all instance IPs), the standard SSH user (`rocky`), and instructions for downloading the SSH keys. Share this output with your class.
 
 ### 3. Teardown
 
@@ -88,14 +110,11 @@ Use the following slugs with the `class=` parameter in your `make setup` command
 ### MySQL Courses
 | Course Title | Class Slug | Architecture Deployed |
 | :--- | :--- | :--- |
-| MySQL Training for Database Operations Specialists | `mysql-ops` | `db1` (Master), `db2` (Replica) |
+| MySQL Training for Database Operations Specialists | `mysql-ops` | `db1` (Source), `db2` (Replica) |
 | MySQL Training for Developers | `mysql-dev` | `db1` |
-| DBA Hands-On (MySQL 101) | `mysql-101` | `db1` |
-| MySQL for Oracle DBA's | `mysql-oracle-dba` | `db1` |
 | ProxySQL Tutorial | `proxysql` | `db1` |
 | Percona Operator for MySQL based on PXC | `mysql-k8s` | `node1` (K8s node) |
 | Percona XtraDB Cluster Tutorial | `pxc` | `pxc` (3 nodes + 1 app) |
-| MySQL Group Replication 101 | `gr-101` | `gr` (3 nodes + 1 app) |
 | Percona Group Replication Tutorial | `gr` | `gr` (3 nodes + 1 app) |
 
 ### MongoDB Courses
@@ -109,7 +128,6 @@ Use the following slugs with the `class=` parameter in your `make setup` command
 | :--- | :--- | :--- |
 | PostgreSQL Training for Database Operations Specialists | `pg-ops` | `db1` |
 | PostgreSQL Training for Developers | `pg-dev` | `db1` |
-| PostgreSQL Tutorial | `pg-tutorial` | `db1` |
 
 ---
 


### PR DESCRIPTION
This PR completely rewrites the README.md to be factual, fluff-free, and aligned with GitHub best practices.

### Key Additions:
- A clear **Prerequisites** and **Installation** section.
- The new **Setting Up a Training Environment** section detailing the `make setup`, `make summary`, and `make teardown` workflow.
- A comprehensive **Supported Courses and Slugs** section with tables mapping Course Titles -> Slugs -> Deployed Architectures.
- Retained the **Advanced Usage** section for running the PHP scripts manually or dealing with legacy CloudFormation templates.
- Mentions the automated VPC drop functionality.

Closes #40
Closes #26