### PR TITLE
Add ps-operator training class

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ There are multiple "machine types" which are used in different training courses:
   * `app`: This instance serves as sysbench, docker, and proxysql for the XtraDB Cluster and Group Replication tutorials. Each student should get 1 app instance.
   * `mysql1`, `mysql2`, `mysql3`: These instances are used in the XtraDB Cluster and Group Replication tutorials. Each student should get 1 of each of these.
   * `node1`: This instance is used in the K8S Operator tutorials. Each student should receive 1 of these.
+  * `psop`: Jumphost for the **ps-operator** class — a single-node `kind` cluster runs locally on the EC2, with Garage S3 pre-deployed for PITR labs and the `percona-server-mysql-operator` repo cloned at the pinned tag. The operator itself is installed by the student during Lab 1. Each student should receive 1 of these.
   * `mongodb`: This instance has the Percona Server for MongoDB packages. Each student should receive 1 of these for the MongoDB training.
 
 There are 2 machine type aliases, `gr` and `pxc`, both are aliases which will deploy each of the 4 types: `app`, `mysql1`, `mysql2`, and `mysql3`

--- a/hosts.yml
+++ b/hosts.yml
@@ -13,6 +13,13 @@
   roles:
     - minikube
 
+# Jumphost for the ps-operator class: kind cluster + Garage S3,
+# PS Operator repo staged for the student to install during Lab 1.
+- hosts: psop
+  gather_facts: no
+  roles:
+    - ps-operator
+
 # This should only match "db1" hosts
 - hosts: db1
   gather_facts: no

--- a/roles/ps-operator/defaults/main.yml
+++ b/roles/ps-operator/defaults/main.yml
@@ -1,0 +1,21 @@
+---
+# Pinned versions for the ps-operator class.
+# Bump in one place when refreshing the class.
+
+ps_operator_version: "v1.1.0"
+ps_operator_repo:    "https://github.com/percona/percona-server-mysql-operator"
+
+garage_version:      "v2.3.0"
+garage_image:        "dxflrs/garage:v2.3.0"
+
+kind_version:        "v0.27.0"
+kubectl_version:     "v1.31.0"
+helm_version:        "v3.16.4"
+k9s_version:         "v0.32.7"
+
+# Lab credentials for the in-cluster Garage S3 backend.
+# Intentionally weak/predictable — students copy these into the operator's
+# credentialsSecret during Lab 2. Do not reuse this pattern in production.
+garage_access_key:   "GKtraining"
+garage_secret_key:   "training-secret-key-do-not-use-in-prod"
+garage_bucket:       "backups"

--- a/roles/ps-operator/files/garage.yaml
+++ b/roles/ps-operator/files/garage.yaml
@@ -1,0 +1,118 @@
+---
+# Single-node Garage S3 for the ps-operator training class.
+# v2.3.0+ auto-creates the default bucket from GARAGE_DEFAULT_* env vars,
+# so no bootstrap Job is needed.
+#
+# Do not use this manifest for anything but training:
+#   - hard-coded credentials are shipped in the manifest
+#   - replication_factor=1 (no durability)
+#   - single Deployment, no HA
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: garage
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: garage-keys
+  namespace: garage
+type: Opaque
+stringData:
+  GARAGE_DEFAULT_ACCESS_KEY: GKtraining
+  GARAGE_DEFAULT_SECRET_KEY: training-secret-key-do-not-use-in-prod
+  GARAGE_DEFAULT_BUCKET:     backups
+  # Generated once per jumphost by ansible and patched into this Secret
+  # before applying. Garage requires a 64-hex-char RPC secret.
+  GARAGE_RPC_SECRET:         REPLACED_BY_ANSIBLE
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: garage-config
+  namespace: garage
+data:
+  garage.toml: |
+    metadata_dir = "/var/lib/garage/meta"
+    data_dir     = "/var/lib/garage/data"
+    db_engine    = "lmdb"
+    replication_factor = 1
+
+    [s3_api]
+    s3_region     = "garage"
+    api_bind_addr = "[::]:3900"
+    root_domain   = ".s3.garage.local"
+
+    [s3_web]
+    bind_addr   = "[::]:3902"
+    root_domain = ".web.garage.local"
+    index       = "index.html"
+
+    [admin]
+    api_bind_addr = "[::]:3903"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: garage-data
+  namespace: garage
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: garage
+  namespace: garage
+spec:
+  replicas: 1
+  strategy: { type: Recreate }
+  selector:
+    matchLabels: { app: garage }
+  template:
+    metadata:
+      labels: { app: garage }
+    spec:
+      containers:
+        - name: garage
+          image: dxflrs/garage:v2.3.0
+          args: ["server"]
+          env:
+            - name: GARAGE_DEFAULT_ACCESS_KEY
+              valueFrom: { secretKeyRef: { name: garage-keys, key: GARAGE_DEFAULT_ACCESS_KEY } }
+            - name: GARAGE_DEFAULT_SECRET_KEY
+              valueFrom: { secretKeyRef: { name: garage-keys, key: GARAGE_DEFAULT_SECRET_KEY } }
+            - name: GARAGE_DEFAULT_BUCKET
+              valueFrom: { secretKeyRef: { name: garage-keys, key: GARAGE_DEFAULT_BUCKET } }
+            - name: GARAGE_RPC_SECRET
+              valueFrom: { secretKeyRef: { name: garage-keys, key: GARAGE_RPC_SECRET } }
+          ports:
+            - { containerPort: 3900, name: s3-api }
+            - { containerPort: 3902, name: s3-web }
+            - { containerPort: 3903, name: admin }
+          volumeMounts:
+            - { name: data,   mountPath: /var/lib/garage }
+            - { name: config, mountPath: /etc/garage.toml, subPath: garage.toml }
+      volumes:
+        - name: data
+          persistentVolumeClaim: { claimName: garage-data }
+        - name: config
+          configMap:
+            name: garage-config
+            defaultMode: 0600
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: garage
+  namespace: garage
+spec:
+  type: NodePort
+  selector: { app: garage }
+  ports:
+    - { name: s3-api, port: 3900, targetPort: 3900, nodePort: 30900 }
+    - { name: admin,  port: 3903, targetPort: 3903, nodePort: 30903 }

--- a/roles/ps-operator/files/kind-config.yaml
+++ b/roles/ps-operator/files/kind-config.yaml
@@ -1,0 +1,8 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: ps-training
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      - { containerPort: 30900, hostPort: 3900, protocol: TCP }  # Garage S3 API
+      - { containerPort: 30903, hostPort: 3903, protocol: TCP }  # Garage admin

--- a/roles/ps-operator/tasks/main.yml
+++ b/roles/ps-operator/tasks/main.yml
@@ -1,0 +1,220 @@
+---
+# Tasks for the ps-operator training class jumphost.
+#
+# Stages a single-node kind cluster on the host, pre-deploys Garage S3 for
+# the PITR labs, and clones the percona-server-mysql-operator repo at the
+# pinned tag for the student to install during Lab 1. The operator itself
+# is intentionally NOT applied — installing it is the first lab.
+#
+# Students sudo -i then run kubectl as root (matches the existing
+# mysql-k8s / minikube class pattern). /root/.kube/config is the kubeconfig.
+
+- name: install jumphost prerequisites
+  dnf:
+    state: present
+    update_cache: yes
+    name:
+      - git
+      - jq
+      - tar
+
+# --- Docker (kind needs it) ---
+
+- name: add Docker CE yum repo
+  yum_repository:
+    name: Docker-CE
+    description: Docker CE Stable
+    baseurl: "https://download.docker.com/linux/centos/{{ ansible_facts['distribution_major_version'] }}/$basearch/stable"
+    gpgcheck: 1
+    gpgkey:
+      - https://download.docker.com/linux/centos/gpg
+
+- name: install Docker + dependencies
+  dnf:
+    state: present
+    update_cache: yes
+    name:
+      - device-mapper-persistent-data
+      - lvm2
+      - docker-ce
+      - docker-ce-cli
+      - containerd.io
+      - conntrack-tools
+
+- name: enable + start docker
+  systemd:
+    name: docker.service
+    enabled: yes
+    state: started
+
+# --- kubectl / kind / helm / k9s ---
+
+- name: install kubectl {{ kubectl_version }}
+  get_url:
+    url: "https://dl.k8s.io/release/{{ kubectl_version }}/bin/linux/amd64/kubectl"
+    dest: /usr/local/bin/kubectl
+    mode: "0755"
+
+- name: install kind {{ kind_version }}
+  get_url:
+    url: "https://kind.sigs.k8s.io/dl/{{ kind_version }}/kind-linux-amd64"
+    dest: /usr/local/bin/kind
+    mode: "0755"
+
+- name: install helm {{ helm_version }}
+  shell: |
+    set -e
+    cd /tmp
+    curl -fsSLO https://get.helm.sh/helm-{{ helm_version }}-linux-amd64.tar.gz
+    tar -xzf helm-{{ helm_version }}-linux-amd64.tar.gz
+    mv linux-amd64/helm /usr/local/bin/helm
+    chmod 0755 /usr/local/bin/helm
+    rm -rf /tmp/helm-{{ helm_version }}-linux-amd64.tar.gz /tmp/linux-amd64
+  args:
+    creates: /usr/local/bin/helm
+
+- name: install k9s {{ k9s_version }}
+  shell: |
+    set -e
+    cd /tmp
+    curl -fsSLO https://github.com/derailed/k9s/releases/download/{{ k9s_version }}/k9s_Linux_amd64.tar.gz
+    tar -xzf k9s_Linux_amd64.tar.gz k9s
+    mv k9s /usr/local/bin/k9s
+    chmod 0755 /usr/local/bin/k9s
+    rm -f /tmp/k9s_Linux_amd64.tar.gz
+  args:
+    creates: /usr/local/bin/k9s
+
+# --- Percona client + toolkit (so students don't have to install on jumphost) ---
+
+- name: Install Percona repo
+  dnf:
+    state: present
+    disable_gpg_check: yes
+    name:
+      - http://repo.percona.com/yum/percona-release-latest.noarch.rpm
+
+- name: enable Percona repos
+  shell: percona-release enable ps-84-lts && percona-release enable pt
+
+- name: install Percona client + toolkit + mysql client
+  dnf:
+    state: present
+    name:
+      - percona-server-client
+      - percona-toolkit
+
+- name: install pt-k8s-debug-collector
+  get_url:
+    url: https://github.com/percona/percona-toolkit/raw/3.5/bin/pt-k8s-debug-collector
+    dest: /usr/local/bin/pt-k8s-debug-collector
+    mode: "0755"
+
+# --- kind cluster ---
+
+- name: stage kind cluster config
+  copy:
+    src: kind-config.yaml
+    dest: /root/kind-config.yaml
+    mode: "0644"
+
+- name: create kind cluster
+  shell: kind create cluster --config /root/kind-config.yaml --wait 5m
+  args:
+    creates: /root/.kube_kind_created
+  register: kind_create
+
+- name: mark kind cluster as created
+  file:
+    path: /root/.kube_kind_created
+    state: touch
+  when: kind_create is changed
+
+# --- Garage S3 (deployed but operator NOT applied) ---
+
+- name: stage Garage manifest
+  copy:
+    src: garage.yaml
+    dest: /root/garage.yaml
+    mode: "0644"
+
+- name: generate per-team Garage RPC secret
+  shell: openssl rand -hex 32 > /root/.garage_rpc_secret
+  args:
+    creates: /root/.garage_rpc_secret
+
+- name: read Garage RPC secret
+  slurp:
+    src: /root/.garage_rpc_secret
+  register: garage_rpc
+
+- name: patch RPC secret into manifest
+  replace:
+    path: /root/garage.yaml
+    regexp: "REPLACED_BY_ANSIBLE"
+    replace: "{{ garage_rpc.content | b64decode | trim }}"
+
+- name: apply Garage manifest
+  shell: kubectl apply -f /root/garage.yaml
+  args:
+    creates: /root/.garage_applied
+
+- name: wait for Garage pod ready
+  shell: kubectl -n garage wait --for=condition=Ready pod -l app=garage --timeout=300s
+  changed_when: false
+
+- name: mark Garage as applied
+  file:
+    path: /root/.garage_applied
+    state: touch
+
+# --- Clone the PS operator repo for the student ---
+
+- name: ensure lab-assets directory
+  file:
+    path: /home/rocky/lab-assets
+    state: directory
+    owner: rocky
+    group: rocky
+    mode: "0755"
+
+- name: clone percona-server-mysql-operator @ {{ ps_operator_version }}
+  git:
+    repo: "{{ ps_operator_repo }}"
+    dest: /home/rocky/lab-assets/percona-server-mysql-operator
+    version: "{{ ps_operator_version }}"
+    depth: 1
+    force: no
+  become_user: rocky
+
+# --- Quality-of-life: kubeconfig is at /root/.kube/config by default,
+#     students sudo -i. Drop a README so they know what's pre-staged. ---
+
+- name: drop class README into lab-assets
+  copy:
+    dest: /home/rocky/lab-assets/README.md
+    owner: rocky
+    group: rocky
+    mode: "0644"
+    content: |
+      # PS Operator class — pre-staged on this jumphost
+
+      ## Cluster
+      - kind cluster `ps-training` running locally (single node, in docker)
+      - kubectl context: `kind-ps-training`
+      - kubeconfig: `/root/.kube/config` — run `sudo -i` first
+
+      ## Pre-deployed
+      - **Garage** S3 (namespace `garage`, Service `garage:3900`)
+        - access key:  `{{ garage_access_key }}`
+        - secret key:  `{{ garage_secret_key }}`
+        - bucket:      `{{ garage_bucket }}`
+        - endpointUrl: `http://garage.garage.svc:3900`
+      - **percona-server-mysql-operator** repo cloned at `{{ ps_operator_version }}`
+        in `./percona-server-mysql-operator/` — the operator is NOT applied
+        (Lab 1 work)
+
+      ## Tooling on PATH
+      - `kubectl`, `kind`, `helm`, `k9s`
+      - `mysql` (Percona Server client)
+      - `pt-k8s-debug-collector`, full `percona-toolkit`

--- a/setup-class.sh
+++ b/setup-class.sh
@@ -13,6 +13,7 @@ if [ -z "$CLASS_SLUG" ] || [ -z "$CLIENT" ] || [ -z "$TEAMS" ]; then
     echo ""
     echo "Available Class Slugs:"
     echo "  MySQL: mysql-ops, mysql-dev, mysql-101, mysql-oracle-dba, proxysql, mysql-k8s, pxc, gr, gr-101"
+    echo "  MySQL Operators: ps-operator"
     echo "  MongoDB: mongo-ops, mongo-dev"
     echo "  PostgreSQL: pg-ops, pg-dev, pg-tutorial"
     exit 1
@@ -29,6 +30,9 @@ case "$CLASS_SLUG" in
         ;;
     "mysql-k8s")
         MACHINE_TYPES="node1"
+        ;;
+    "ps-operator")
+        MACHINE_TYPES="psop"
         ;;
     "pxc")
         MACHINE_TYPES="pxc"

--- a/start-instances.php
+++ b/start-instances.php
@@ -4,7 +4,7 @@
 include 'config.php';
 
 $actions      = array('ADD', 'DROP', 'LISTINSTANCES', 'GETANSIBLEHOSTS', 'GETCSV', 'GETSSHCONFIG', 'SYNCDYNAMO');
-$machineTypes = array('db1', 'db2', 'scoreboard', 'app', 'pmm', 'mysql1', 'mysql2', 'mysql3', 'pxc', 'gr', 'node1', 'node2', 'node3', 'node4', 'mongodb');
+$machineTypes = array('db1', 'db2', 'scoreboard', 'app', 'pmm', 'mysql1', 'mysql2', 'mysql3', 'pxc', 'gr', 'node1', 'node2', 'node3', 'node4', 'mongodb', 'psop');
 
 const DEBUG = false;
 
@@ -425,6 +425,7 @@ function addNewInstance()
 				$instanceType = "t3.xlarge";
 				break;
 			case "node1":
+			case "psop":
 				$instanceType = "t3.2xlarge";
 				break;
 		}


### PR DESCRIPTION
## Description

Adds a new `ps-operator` training class — a 16-hour, hands-on course on the Percona Operator for MySQL based on Percona Server.

Each student gets a single EC2 jumphost (`psop` machine type, `t3.2xlarge`) running a single-node [kind](https://kind.sigs.k8s.io/) cluster locally. The ansible role pre-stages tooling (`kubectl`, `helm`, `k9s`, `percona-toolkit`, `pt-k8s-debug-collector`, Percona Server client), deploys [Garage](https://garagehq.deuxfleurs.fr/) v2.3.0 in-cluster as the S3 backend for PITR labs, and clones the `percona-server-mysql-operator` repo at `v1.1.0`. The operator itself is intentionally NOT applied — installing the bundle is Lab 1.

Garage was chosen over MinIO because MinIO Community Edition was archived in 2026 and is no longer maintained. v2.3.0 introduced env-var-driven auto-bucket-create, so no bootstrap Job is needed.

## Related Issue

Closes #46

## Checklist

- [x] I have read the [CONTRIBUTORS.md](CONTRIBUTORS.md) file.
- [x] My code follows the existing style and conventions.
- [ ] I have added tests (if applicable) and verified the changes. *(No tests in repo today; ansible-playbook --syntax-check passes; manual end-to-end provisioning will be verified on first class delivery.)*
- [x] Documentation has been updated (if applicable). *(README.md machine-types section + lab-assets README dropped onto each jumphost.)*

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Verification

- `bash -n setup-class.sh` → OK
- `php -l start-instances.php` → OK
- `python -c "import yaml; ..."` on all new YAML files → OK
- `ansible-playbook --syntax-check hosts.yml` → OK (only warnings about pre-existing missing inventory groups in test inventory)
- `ansible-lint` flagged 245 pre-existing style violations across the playbook — none introduced by this PR; my new play follows the same conventions as the existing ones. Style cleanup is tracked separately under #32.

## Pinned versions

| | Version | Released |
|---|---|---|
| PS Operator | v1.1.0 | 2026-04-17 |
| Garage | v2.3.0 | 2026-04-16 |
| kind | v0.27.0 | — |
| kubectl | v1.31.0 | — |
| helm | v3.16.4 | — |
| k9s | v0.32.7 | — |

All in `roles/ps-operator/defaults/main.yml` — one-line bump to refresh.

## Follow-up work (separate PR)

- Slide-source markdown for the two decks lives in `percona/training-material` — separate PR there.
