### PR TITLE
feat: add PostgreSQL 17 training class (pg1/pg2/pg3 + pg alias)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,14 @@ There are 3 machine type aliases:
   * `gr` and `pxc` each deploy the 4 types `app`, `mysql1`, `mysql2`, and `mysql3` (XtraDB Cluster / Group Replication).
   * `pg` deploys one full PostgreSQL student set: `pg1`, `pg2`, and `pg3`.
 
-> **Security group note (PostgreSQL course):** the training VPC opens only 22/80/443/8080.
-> The `pg` nodes also need intra-VPC traffic on **5432** (PostgreSQL) plus the HA-lab ports
-> **8008** (Patroni REST), **2379/2380** (etcd), **6432** (PgBouncer), and **5000/5001**
-> (HAProxy). Add a self-referencing inbound rule on the training security group (allow all
-> traffic from the SG to itself) before running the replication/HA labs.
+> **Inter-node traffic (PostgreSQL HA labs):** no manual security-group changes are
+> required. `setup-vpc.php` automatically adds a self-referencing rule to the training
+> security group that allows all traffic between training instances. This covers the
+> ports the `pg` HA labs use — **5432** (PostgreSQL), **8008** (Patroni REST),
+> **2379/2380** (etcd), **6432** (PgBouncer), and **5000/5001** (HAProxy) — as well as
+> the PXC/GR cluster ports, without exposing anything to the internet. (Existing VPCs
+> created before this change get the rule added automatically on the next
+> `setup-vpc.php -a ADD` run.)
 
 ## Set Up Instances
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ There are multiple "machine types" which are used in different training courses:
   * `pg1`, `pg2`, `pg3`: Used for the **PostgreSQL DBA & Operations** course (Percona Distribution for PostgreSQL 17). `pg1` is the primary (+ sysbench client, first PMM-monitored node); `pg2` is the standby/promoted primary; `pg3` is the pgBackRest repository, DR target, third Patroni node, and runs HAProxy/PgBouncer. Each student should receive 1 of each. Course content lives in `pg-training/` in the `training-material` repo.
   * `pmm`: A shared **PMM Server** (one per class, like `scoreboard`). Runs PMM Server 3 in Docker, reachable on port 443. Pass its private IP to the PostgreSQL play with `-e pmm_server_ip=<ip>` so the `pg` nodes register against it.
 
+> 🐘 **Standing up the PostgreSQL class for the first time?** Start with
+> [`roles/postgres/README.md`](roles/postgres/README.md) — the step-by-step provisioning
+> sequence (with timings), the smoke test, and where to fan out from there.
+
 There are 3 machine type aliases:
   * `gr` and `pxc` each deploy the 4 types `app`, `mysql1`, `mysql2`, and `mysql3` (XtraDB Cluster / Group Replication).
   * `pg` deploys one full PostgreSQL student set: `pg1`, `pg2`, and `pg3`.

--- a/README.md
+++ b/README.md
@@ -68,8 +68,18 @@ There are multiple "machine types" which are used in different training courses:
   * `mysql1`, `mysql2`, `mysql3`: These instances are used in the XtraDB Cluster and Group Replication tutorials. Each student should get 1 of each of these.
   * `node1`: This instance is used in the K8S Operator tutorials. Each student should receive 1 of these.
   * `mongodb`: This instance has the Percona Server for MongoDB packages. Each student should receive 1 of these for the MongoDB training.
+  * `pg1`, `pg2`, `pg3`: Used for the **PostgreSQL DBA & Operations** course (Percona Distribution for PostgreSQL 17). `pg1` is the primary (+ sysbench client, first PMM-monitored node); `pg2` is the standby/promoted primary; `pg3` is the pgBackRest repository, DR target, third Patroni node, and runs HAProxy/PgBouncer. Each student should receive 1 of each. Course content lives in `pg-training/` in the `training-material` repo.
+  * `pmm`: A shared **PMM Server** (one per class, like `scoreboard`). Runs PMM Server 3 in Docker, reachable on port 443. Pass its private IP to the PostgreSQL play with `-e pmm_server_ip=<ip>` so the `pg` nodes register against it.
 
-There are 2 machine type aliases, `gr` and `pxc`, both are aliases which will deploy each of the 4 types: `app`, `mysql1`, `mysql2`, and `mysql3`
+There are 3 machine type aliases:
+  * `gr` and `pxc` each deploy the 4 types `app`, `mysql1`, `mysql2`, and `mysql3` (XtraDB Cluster / Group Replication).
+  * `pg` deploys one full PostgreSQL student set: `pg1`, `pg2`, and `pg3`.
+
+> **Security group note (PostgreSQL course):** the training VPC opens only 22/80/443/8080.
+> The `pg` nodes also need intra-VPC traffic on **5432** (PostgreSQL) plus the HA-lab ports
+> **8008** (Patroni REST), **2379/2380** (etcd), **6432** (PgBouncer), and **5000/5001**
+> (HAProxy). Add a self-referencing inbound rule on the training security group (allow all
+> traffic from the SG to itself) before running the replication/HA labs.
 
 ## Set Up Instances
 

--- a/hosts.yml
+++ b/hosts.yml
@@ -277,3 +277,56 @@
       file:
         path: "/var/lib/mongo/"
         state: absent
+
+# =====================================================================
+# PostgreSQL DBA & Operations course (Percona Distribution for PG 17).
+# Per-student set: pg1 (primary), pg2 (standby), pg3 (repo/DR/HA node).
+# `common` (the `- hosts: all` play above) already sets hostnames and
+# builds /etc/hosts so pg1/pg2/pg3 resolve within each team.
+# Course content: pg-training/ in the training-material repo.
+# =====================================================================
+- hosts: pg1:pg2:pg3
+  gather_facts: no
+  environment:
+    PERCONA_TELEMETRY_DISABLE: 1
+  roles:
+    - postgres
+
+# Shared class PMM Server (one per class), like `scoreboard`.
+# Pass the pmm node's private IP to the pg play with:
+#   ansible-playbook -i <inv> hosts.yml -e pmm_server_ip=<pmm-private-ip>
+- hosts: pmm
+  gather_facts: no
+  environment:
+    PERCONA_TELEMETRY_DISABLE: 1
+  tasks:
+    - name: Add Docker CE repo
+      ansible.builtin.yum_repository:
+        name: docker-ce
+        description: Docker CE Stable
+        baseurl: "https://download.docker.com/linux/centos/$releasever/$basearch/stable"
+        gpgcheck: true
+        gpgkey: https://download.docker.com/linux/centos/gpg
+
+    - name: Install Docker
+      ansible.builtin.dnf:
+        name:
+          - docker-ce
+          - docker-ce-cli
+          - containerd.io
+        state: present
+
+    - name: Enable and start Docker
+      ansible.builtin.systemd:
+        name: docker
+        enabled: true
+        state: started
+
+    - name: Deploy PMM Server 3 (Watchtower deployment, listens on 443)
+      ansible.builtin.shell: |
+        set -o pipefail
+        docker ps -a | grep -qw pmm-server || \
+          curl -fsSL https://www.percona.com/get/pmm | /bin/bash
+      args:
+        executable: /bin/bash
+      changed_when: false

--- a/hosts.yml
+++ b/hosts.yml
@@ -344,5 +344,14 @@
   gather_facts: no
   environment:
     PERCONA_TELEMETRY_DISABLE: 1
+  vars:
+    # Auto-derive the shared PMM server's private IP from the inventory (the `pmm`
+    # group, with the privateIp host var emitted by GETANSIBLEHOSTS), so no manual
+    # `-e pmm_server_ip=` is needed. Empty when there is no pmm host → the role skips
+    # PMM client registration. Override on the command line with -e if you must.
+    pmm_server_ip: >-
+      {{ hostvars[groups['pmm'][0]].privateIp
+         if (groups['pmm'] | default([]) | length > 0)
+         else '' }}
   roles:
     - postgres

--- a/hosts.yml
+++ b/hosts.yml
@@ -280,21 +280,19 @@
 
 # =====================================================================
 # PostgreSQL DBA & Operations course (Percona Distribution for PG 17).
-# Per-student set: pg1 (primary), pg2 (standby), pg3 (repo/DR/HA node).
+# Per-student set: pg1 (primary), pg2 (standby), pg3 (repo/DR/HA node)
+# plus one shared PMM server.
 # `common` (the `- hosts: all` play above) already sets hostnames and
 # builds /etc/hosts so pg1/pg2/pg3 resolve within each team.
 # Course content: pg-training/ in the training-material repo.
-# =====================================================================
-- hosts: pg1:pg2:pg3
-  gather_facts: no
-  environment:
-    PERCONA_TELEMETRY_DISABLE: 1
-  roles:
-    - postgres
-
-# Shared class PMM Server (one per class), like `scoreboard`.
+#
+# IMPORTANT: the `pmm` play runs FIRST so the PMM server is up (and ready)
+# before the pg nodes try to register their pmm-client against it.
 # Pass the pmm node's private IP to the pg play with:
 #   ansible-playbook -i <inv> hosts.yml -e pmm_server_ip=<pmm-private-ip>
+# =====================================================================
+
+# Shared class PMM Server (one per class), like `scoreboard`.
 - hosts: pmm
   gather_facts: no
   environment:
@@ -330,3 +328,21 @@
       args:
         executable: /bin/bash
       changed_when: false
+
+    # Wait until the PMM web UI answers, so the pg nodes can register below.
+    - name: Wait for PMM Server to be ready (port 443)
+      ansible.builtin.uri:
+        url: "https://localhost/v1/readyz"
+        validate_certs: false
+        status_code: [200]
+      register: pmm_ready
+      until: pmm_ready.status == 200
+      retries: 30
+      delay: 10
+
+- hosts: pg1:pg2:pg3
+  gather_facts: no
+  environment:
+    PERCONA_TELEMETRY_DISABLE: 1
+  roles:
+    - postgres

--- a/roles/postgres/README.md
+++ b/roles/postgres/README.md
@@ -1,0 +1,76 @@
+# Stand up the PostgreSQL-17 training environment — Start Here
+
+**You know AWS/Ansible basics but nothing about *this* class's setup. Read this one page
+first.** It gives you the provisioning sequence, how long each step takes, and what to
+verify — then fans out to the detail.
+
+> This builds the environment for the **Percona PostgreSQL DBA & Operations** course. The
+> course content (slides, labs, instructor docs) lives in `pg-training/` in the
+> **`training-material`** repo; the deeper provisioning write-up is
+> [`pg-training/infra/README.md`](../../../training-material/pg-training/infra/README.md).
+
+---
+
+## What you're building
+
+Per **student**: three EC2 nodes — `pg1` (primary + sysbench client), `pg2` (standby),
+`pg3` (pgBackRest repo / DR / 3rd Patroni node / HAProxy+PgBouncer). Per **class**: one
+shared `pmm` server. All run Percona Distribution for PostgreSQL 17 on the EL9 training
+AMI. The `pg` alias expands to one full `pg1,pg2,pg3` student set.
+
+This `postgres` role brings each node up to a clean, **primary/standby-ready PG 17
+cluster** — Patroni/etcd/HAProxy/PgBouncer are installed *during the Block 3 labs*, not
+pre-baked (standing them up is the point of those labs).
+
+---
+
+## The provisioning sequence
+
+Run from your `training-aws` checkout. Example: client tag `ACME`, region `us-west-2`, 8
+students. Do this **the day before class**, not the morning of.
+
+| # | Step | Command | ~Time |
+| - | ---- | ------- | ----- |
+| 1 | Create/refresh the VPC (auto-adds the intra-SG self-reference rule the HA labs need) | `./setup-vpc.php -a ADD -r us-west-2 -p ACME` | ~1 min |
+| 2 | Launch the shared PMM server | `./start-instances.php -a ADD -r us-west-2 -p ACME -c 1 -m pmm -i <ami>` | ~2 min to boot |
+| 3 | Launch one `pg` set per student | `./start-instances.php -a ADD -r us-west-2 -p ACME -c 8 -m pg -i <ami>` | ~2–3 min to boot |
+| 4 | Wait for SSH, then build the inventory | `./start-instances.php -a GETANSIBLEHOSTS -r us-west-2 -p ACME > ansible_hosts_acme` | — |
+| 5 | Provision (PMM play runs first, then the pg nodes register to it) | `ansible-playbook -i ansible_hosts_acme hosts.yml -e pmm_server_ip=<pmm-private-ip>` | ~10–15 min |
+| 6 | Smoke-test (below) | — | ~5 min |
+| — | **Tear down after class** | `./start-instances.php -a DROP -r us-west-2 -p ACME -i <ami>`, then delete the VPC | ~3 min |
+
+> **Order matters in step 5:** `hosts.yml` runs the `pmm` play before the `pg` play and
+> waits for PMM to be ready, so the clients can register. Always pass `-e pmm_server_ip=`.
+
+---
+
+## Verify before you walk away (smoke test)
+
+On any student's `pg1` (as `postgres`):
+
+```sql
+SELECT count(*) FROM bluebox.film;        -- expect 7836 — the dataset loaded
+SHOW listen_addresses;                     -- '*' — remote connections allowed
+SELECT 1 FROM pg_roles WHERE rolname='replicator';   -- exists — replication labs ready
+```
+
+And from the shell: `systemctl is-active postgresql-17` → `active`; the `pmm` server's web
+UI is reachable on `https://<pmm-public-ip>` (port 443). If `bluebox.film` is empty or the
+`postgres` password isn't set, re-run the `pg` play — those are the two things that bite.
+
+---
+
+## Fan out to the detail
+
+- **[`pg-training/infra/README.md`](../../../training-material/pg-training/infra/README.md)**
+  — the full provisioning write-up: topology rationale, `hosts.yml` additions, the two-pass
+  SSH-key note for pgBackRest, connection sheet/keys, what the role installs.
+- **[`tasks/main.yml`](tasks/main.yml)** — the exact install/config sequence on every pg node.
+- **[`tasks/pg1.yml`](tasks/pg1.yml)** — pg1-only extras (Bluebox dataset, `replicator`/`sysbench` roles, PostGIS).
+- **[`tasks/pmm.yml`](tasks/pmm.yml)** — the shared PMM server setup.
+- **[`defaults/main.yml`](defaults/main.yml)** — passwords and tunables (keep in sync with the labs).
+- **Per-AMI gotchas** (package names, etcd, sysbench path) — `INSTRUCTOR-NOTES.md` in the course repo.
+- **Proof it works** — `LAB-VALIDATION-REPORT.md` in the course repo records a full end-to-end run.
+
+> The top-level [`README.md`](../../README.md) "machine types" section covers the `pg`/`pmm`
+> aliases and the security-group rule in the context of all the training machine types.

--- a/roles/postgres/README.md
+++ b/roles/postgres/README.md
@@ -24,23 +24,46 @@ pre-baked (standing them up is the point of those labs).
 
 ---
 
-## The provisioning sequence
+## The provisioning sequence — use `make`
 
-Run from your `training-aws` checkout. Example: client tag `ACME`, region `us-west-2`, 8
-students. Do this **the day before class**, not the morning of.
+`make` is the canonical interface (see `make help`). The PostgreSQL class slug is
+**`pg-ops`** (`pg-dev`/`pg-tutorial` are aliases). One `make setup` does the whole thing:
+creates the VPC, launches one `pg` set (pg1/pg2/pg3) per team **plus the shared PMM
+server**, builds the Ansible inventory, and provisions everything. Do this **the day
+before class**, not the morning of.
+
+Example: client tag `ACME`, 8 students, default region `us-west-2`:
 
 | # | Step | Command | ~Time |
 | - | ---- | ------- | ----- |
-| 1 | Create/refresh the VPC (auto-adds the intra-SG self-reference rule the HA labs need) | `./setup-vpc.php -a ADD -r us-west-2 -p ACME` | ~1 min |
-| 2 | Launch the shared PMM server | `./start-instances.php -a ADD -r us-west-2 -p ACME -c 1 -m pmm -i <ami>` | ~2 min to boot |
-| 3 | Launch one `pg` set per student | `./start-instances.php -a ADD -r us-west-2 -p ACME -c 8 -m pg -i <ami>` | ~2–3 min to boot |
-| 4 | Wait for SSH, then build the inventory | `./start-instances.php -a GETANSIBLEHOSTS -r us-west-2 -p ACME > ansible_hosts_acme` | — |
-| 5 | Provision (PMM play runs first, then the pg nodes register to it) | `ansible-playbook -i ansible_hosts_acme hosts.yml -e pmm_server_ip=<pmm-private-ip>` | ~10–15 min |
-| 6 | Smoke-test (below) | — | ~5 min |
-| — | **Tear down after class** | `./start-instances.php -a DROP -r us-west-2 -p ACME -i <ami>`, then delete the VPC | ~3 min |
+| 1 | (Optional) find the current training AMI | `make list-amis` | — |
+| 2 | **Provision the whole class** — VPC + pg sets + shared PMM + Ansible | `make setup class=pg-ops client=ACME teams=8` | ~15–20 min |
+| 3 | Print the connection sheet / dashboard URL | `make summary client=ACME` | — |
+| 4 | Smoke-test (below) | — | ~5 min |
+| — | **Tear down after class** | `make teardown client=ACME` | ~3 min |
 
-> **Order matters in step 5:** `hosts.yml` runs the `pmm` play before the `pg` play and
-> waits for PMM to be ready, so the clients can register. Always pass `-e pmm_server_ip=`.
+Add `region=<aws-region>` to any target to use a non-default region (e.g.
+`make setup class=pg-ops client=ACME teams=8 region=eu-west-1`).
+
+> **What `make setup` wires up for you (no manual steps):** the VPC gets the intra-SG
+> self-reference rule the HA labs need; `hosts.yml` runs the `pmm` play first and waits for
+> PMM to be ready; and the pg play **auto-derives `pmm_server_ip` from the inventory**, so
+> the `pg` nodes register against the shared PMM server with no IP to copy by hand.
+
+<details>
+<summary>Under the hood (what <code>make setup</code> runs, if you ever need to drive it by hand)</summary>
+
+`make setup class=pg-ops …` calls `setup-class.sh`, which runs:
+
+```bash
+./setup-vpc.php       -a ADD -r <region> -p ACME
+./start-instances.php -a ADD -r <region> -p ACME -c 8 -m pg   -i <ami>   # per-team sets
+./start-instances.php -a ADD -r <region> -p ACME -c 1 -m pmm  -i <ami>   # shared PMM
+./start-instances.php -a GETANSIBLEHOSTS -r <region> -p ACME > ansible_hosts_ACME
+ansible-playbook -i ansible_hosts_ACME hosts.yml                          # pmm_server_ip auto-derived
+```
+`make teardown client=ACME` runs the `DROP` actions for the instances **and** the VPC.
+</details>
 
 ---
 

--- a/roles/postgres/defaults/main.yml
+++ b/roles/postgres/defaults/main.yml
@@ -1,0 +1,27 @@
+---
+# Defaults for the `postgres` training role.
+# Used by the pg1/pg2/pg3 machine types (Percona PostgreSQL DBA & Operations course).
+
+pg_major: 17
+pg_bindir: "/usr/pgsql-{{ pg_major }}/bin"
+pg_datadir: "/var/lib/pgsql/{{ pg_major }}/data"
+pg_service: "postgresql-{{ pg_major }}"
+pg_percona_channel: "ppg-{{ pg_major }}"
+
+# The private range students connect from (training VPC is 10.11.0.0/16;
+# 10.0.0.0/8 is a convenient superset for a throwaway class environment).
+pg_trusted_cidr: "10.0.0.0/8"
+
+# Training-only passwords. NEVER use these outside a throwaway class env.
+pg_sysbench_password: "secret"
+pg_replicator_password: "secret"
+pg_pmm_password: "secret"
+
+# Shared class PMM server: set to the pmm node's private IP at provision time
+# (e.g. -e pmm_server_ip=10.11.0.50). Empty = skip PMM client registration.
+pmm_server_ip: ""
+
+# Bluebox sample dataset (loaded on pg1 only)
+bluebox_load: true
+bluebox_schema_url: "https://raw.githubusercontent.com/ryanbooz/bluebox/main/bluebox_schema.sql"
+bluebox_data_url: "https://raw.githubusercontent.com/ryanbooz/bluebox/main/bluebox_data.sql.gz"

--- a/roles/postgres/handlers/main.yml
+++ b/roles/postgres/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+- name: restart postgresql
+  ansible.builtin.systemd:
+    name: "{{ pg_service }}"
+    state: restarted
+
+- name: reload postgresql
+  ansible.builtin.systemd:
+    name: "{{ pg_service }}"
+    state: reloaded

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -1,0 +1,131 @@
+---
+# =====================================================================
+# Percona Distribution for PostgreSQL 17 — training role (RHEL/EL9)
+# =====================================================================
+# Machine types: pg1 (primary), pg2 (standby), pg3 (pgBackRest repo /
+# DR / 3rd Patroni node / HAProxy + PgBouncer). One shared `pmm` server
+# per class (see the pmm play in hosts.yml).
+#
+# Cross-node name resolution (pg1/pg2/pg3 within a team) is provided by
+# the `common` role's hosts.j2, so this role does NOT manage /etc/hosts.
+#
+# Course content: pg-training/ in the training-material repo.
+# ---------------------------------------------------------------------
+
+# ---- 1. Percona repository ------------------------------------------
+- name: Install percona-release
+  ansible.builtin.dnf:
+    name: "https://repo.percona.com/yum/percona-release-latest.noarch.rpm"
+    state: present
+    disable_gpg_check: true
+
+- name: Enable Percona Distribution for PostgreSQL {{ pg_major }}
+  ansible.builtin.command: "percona-release setup {{ pg_percona_channel }}"
+  args:
+    creates: "/etc/yum.repos.d/percona-ppg-{{ pg_major }}-release.repo"
+
+# ---- 2. Packages: server + Percona toolchain ------------------------
+- name: Install PostgreSQL server + training toolchain
+  ansible.builtin.dnf:
+    state: present
+    disable_gpg_check: true
+    name:
+      - "percona-postgresql{{ pg_major }}-server"
+      - "percona-postgresql{{ pg_major }}-contrib"
+      - sysbench
+      - chrony       # accurate clocks matter for PITR + replication
+      - git
+      - vim
+
+# pg_stat_monitor / pgbackrest package names can vary slightly by build;
+# install best-effort and let Lab provisioning confirm exact names.
+- name: Install pg_stat_monitor + pgBackRest (best-effort)
+  ansible.builtin.dnf:
+    state: present
+    disable_gpg_check: true
+    name:
+      - "percona-pg-stat-monitor{{ pg_major }}"
+      - percona-pgbackrest
+  ignore_errors: true
+
+- name: Install PMM client (best-effort; registered later if pmm_server_ip set)
+  ansible.builtin.dnf:
+    name: pmm-client
+    state: present
+  ignore_errors: true
+
+# ---- 3. postgres user: shell + SSH key (pgBackRest convenience) -----
+- name: Ensure the postgres user has a login shell
+  ansible.builtin.user:
+    name: postgres
+    shell: /bin/bash
+
+- name: Generate an SSH key for the postgres user (used in pgBackRest/Patroni labs)
+  become: true
+  become_user: postgres
+  ansible.builtin.command: "ssh-keygen -t rsa -N '' -f ~/.ssh/id_rsa"
+  args:
+    creates: "/var/lib/pgsql/.ssh/id_rsa"
+# NOTE: key *distribution* between team nodes is done by students with
+# ssh-copy-id in Lab 6 / Lab 12 (intentional teaching step).
+
+# ---- 4. Initialize + configure + start the cluster ------------------
+- name: Initialize the data directory
+  ansible.builtin.command: "{{ pg_bindir }}/postgresql-{{ pg_major }}-setup initdb"
+  args:
+    creates: "{{ pg_datadir }}/PG_VERSION"
+
+- name: Create conf.d directory
+  ansible.builtin.file:
+    path: "{{ pg_datadir }}/conf.d"
+    state: directory
+    owner: postgres
+    group: postgres
+    mode: "0700"
+
+- name: Drop in training configuration
+  ansible.builtin.template:
+    src: percona-training.conf.j2
+    dest: "{{ pg_datadir }}/conf.d/percona-training.conf"
+    owner: postgres
+    group: postgres
+    mode: "0600"
+  notify: restart postgresql
+
+- name: Ensure conf.d is included from postgresql.conf
+  ansible.builtin.lineinfile:
+    path: "{{ pg_datadir }}/postgresql.conf"
+    line: "include_dir = 'conf.d'"
+    state: present
+  notify: restart postgresql
+
+- name: Allow subnet connections in pg_hba.conf
+  ansible.builtin.blockinfile:
+    path: "{{ pg_datadir }}/pg_hba.conf"
+    marker: "# {mark} PG TRAINING HBA"
+    owner: postgres
+    group: postgres
+    block: |
+      # Training: allow the class subnet (scram). Tighten for real workloads.
+      host    all             all             {{ pg_trusted_cidr }}    scram-sha-256
+      host    replication     replicator      {{ pg_trusted_cidr }}    scram-sha-256
+  notify: reload postgresql
+
+- name: Enable and start PostgreSQL
+  ansible.builtin.systemd:
+    name: "{{ pg_service }}"
+    enabled: true
+    state: started
+
+- name: Apply any pending config (flush handlers before pg1/pmm steps)
+  ansible.builtin.meta: flush_handlers
+
+# ---- 5. pg1-only: dataset, sysbench db, replicator role -------------
+- name: pg1 setup (dataset + roles)
+  ansible.builtin.include_tasks: pg1.yml
+  when: machinetype == 'pg1'
+
+# ---- 6. Optional: register with the shared class PMM server ---------
+- name: Register node with PMM
+  ansible.builtin.include_tasks: pmm.yml
+  when: pmm_server_ip | length > 0

--- a/roles/postgres/tasks/main.yml
+++ b/roles/postgres/tasks/main.yml
@@ -120,6 +120,14 @@
 - name: Apply any pending config (flush handlers before pg1/pmm steps)
   ansible.builtin.meta: flush_handlers
 
+# pg_rewind (Block 3 lab10) and Patroni (lab12) authenticate as the `postgres`
+# superuser over TCP, so it needs a password. Training-only — never in production.
+- name: Set the postgres superuser password (training)
+  become: true
+  become_user: postgres
+  ansible.builtin.command: psql -c "ALTER USER postgres PASSWORD '{{ pg_superuser_password | default('secret') }}'"
+  changed_when: false
+
 # ---- 5. pg1-only: dataset, sysbench db, replicator role -------------
 - name: pg1 setup (dataset + roles)
   ansible.builtin.include_tasks: pg1.yml

--- a/roles/postgres/tasks/pg1.yml
+++ b/roles/postgres/tasks/pg1.yml
@@ -1,6 +1,17 @@
 ---
-# pg1-only setup: replication role, sysbench database, Bluebox dataset.
+# pg1-only setup: PostGIS (for Bluebox), replication role, sysbench db, Bluebox dataset.
 # All via psql over the local socket as the postgres user (no extra collections).
+
+# The Bluebox schema requires PostGIS (it creates a topology schema + geography
+# columns). Without it, the schema load aborts and leaves an empty bluebox schema.
+- name: Install PostGIS for the Bluebox dataset (pg1)
+  ansible.builtin.dnf:
+    name:
+      - "percona-postgis33_{{ pg_major }}"
+      - "percona-postgis33_{{ pg_major }}-client"
+    state: present
+    disable_gpg_check: true
+  ignore_errors: true
 
 - name: Create the replicator role (Block 3 replication labs)
   become: true

--- a/roles/postgres/tasks/pg1.yml
+++ b/roles/postgres/tasks/pg1.yml
@@ -1,0 +1,51 @@
+---
+# pg1-only setup: replication role, sysbench database, Bluebox dataset.
+# All via psql over the local socket as the postgres user (no extra collections).
+
+- name: Create the replicator role (Block 3 replication labs)
+  become: true
+  become_user: postgres
+  ansible.builtin.shell: |
+    psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='replicator'" | grep -q 1 || \
+      psql -c "CREATE ROLE replicator WITH REPLICATION LOGIN ENCRYPTED PASSWORD '{{ pg_replicator_password }}';"
+  changed_when: false
+
+- name: Create sysbench role + database (Block 4 load/monitoring labs)
+  become: true
+  become_user: postgres
+  ansible.builtin.shell: |
+    psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='sysbench'" | grep -q 1 || \
+      psql -c "CREATE USER sysbench WITH LOGIN ENCRYPTED PASSWORD '{{ pg_sysbench_password }}';"
+    psql -tAc "SELECT 1 FROM pg_database WHERE datname='sbtest'" | grep -q 1 || \
+      psql -c "CREATE DATABASE sbtest WITH OWNER=sysbench;"
+  changed_when: false
+
+- name: Download Bluebox dataset
+  become: true
+  become_user: postgres
+  ansible.builtin.get_url:
+    url: "{{ item.url }}"
+    dest: "/tmp/{{ item.name }}"
+  loop:
+    - { url: "{{ bluebox_schema_url }}", name: "bluebox_schema.sql" }
+    - { url: "{{ bluebox_data_url }}",   name: "bluebox_data.sql.gz" }
+  when: bluebox_load | bool
+  ignore_errors: true   # don't fail provisioning if upstream is unreachable
+
+- name: Load Bluebox (idempotent — skips if already populated)
+  become: true
+  become_user: postgres
+  ansible.builtin.shell: |
+    set -e
+    if psql -d bluebox -tAc "SELECT count(*) FROM bluebox.film" 2>/dev/null | grep -qE '[1-9]'; then
+      echo "bluebox already loaded"; exit 0
+    fi
+    createdb bluebox 2>/dev/null || true
+    gunzip -f /tmp/bluebox_data.sql.gz 2>/dev/null || true
+    psql -d bluebox -f /tmp/bluebox_schema.sql
+    psql -d bluebox -f /tmp/bluebox_data.sql
+  args:
+    executable: /bin/bash
+  when: bluebox_load | bool
+  changed_when: false
+  ignore_errors: true

--- a/roles/postgres/tasks/pmm.yml
+++ b/roles/postgres/tasks/pmm.yml
@@ -1,0 +1,45 @@
+---
+# Register this node with the shared class PMM server and add the
+# PostgreSQL instance for monitoring. Requires pmm-client installed and
+# `pmm_server_ip` set to the class pmm node's private IP.
+
+- name: Enable the PMM client repo channel
+  ansible.builtin.command: "percona-release enable pmm3-client"
+  args:
+    creates: "/etc/yum.repos.d/percona-pmm3-client-release.repo"
+  ignore_errors: true
+
+- name: Ensure pmm-client is installed
+  ansible.builtin.dnf:
+    name: pmm-client
+    state: present
+  ignore_errors: true
+
+- name: Create the PMM monitoring role in PostgreSQL
+  become: true
+  become_user: postgres
+  ansible.builtin.shell: |
+    psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='pmm'" | grep -q 1 || \
+      psql -c "CREATE USER pmm WITH SUPERUSER ENCRYPTED PASSWORD '{{ pg_pmm_password }}';"
+  changed_when: false
+
+- name: Allow local pmm connections in pg_hba.conf
+  ansible.builtin.lineinfile:
+    path: "{{ pg_datadir }}/pg_hba.conf"
+    line: "host    all    pmm    127.0.0.1/32    scram-sha-256"
+    insertafter: EOF
+  notify: reload postgresql
+
+- name: Register the node with the PMM server
+  ansible.builtin.command: >
+    pmm-admin config --server-insecure-tls
+    --server-url=https://admin:admin@{{ pmm_server_ip }}:443
+  changed_when: false
+  failed_when: false
+
+- name: Add PostgreSQL to PMM monitoring
+  ansible.builtin.command: >
+    pmm-admin add postgresql --username=pmm --password={{ pg_pmm_password }}
+    {{ machinetype }}-{{ team | default('T0') }}-postgresql
+  changed_when: false
+  failed_when: false

--- a/roles/postgres/tasks/pmm.yml
+++ b/roles/postgres/tasks/pmm.yml
@@ -37,9 +37,17 @@
   changed_when: false
   failed_when: false
 
-- name: Add PostgreSQL to PMM monitoring
+- name: Create pg_stat_monitor view for PMM QAN (in the postgres db)
+  become: true
+  become_user: postgres
+  ansible.builtin.command: psql -d postgres -c "CREATE EXTENSION IF NOT EXISTS pg_stat_monitor;"
+  changed_when: false
+  failed_when: false
+
+- name: Add PostgreSQL to PMM monitoring (pg_stat_monitor query source)
   ansible.builtin.command: >
     pmm-admin add postgresql --username=pmm --password={{ pg_pmm_password }}
+    --query-source=pgstatmonitor
     {{ machinetype }}-{{ team | default('T0') }}-postgresql
   changed_when: false
   failed_when: false

--- a/roles/postgres/templates/percona-training.conf.j2
+++ b/roles/postgres/templates/percona-training.conf.j2
@@ -1,0 +1,40 @@
+# Managed by the `postgres` training role — drop-in under conf.d/.
+# Lab-friendly starting configuration for a 2 vCPU / 8 GB node (t3.large).
+# Block 4 of the course has students change several of these and observe the effect.
+
+#--- Connections ---
+listen_addresses = '*'
+max_connections = 100
+
+#--- Memory (~8 GB node) ---
+shared_buffers = 2GB
+effective_cache_size = 6GB
+work_mem = 16MB
+maintenance_work_mem = 512MB
+
+#--- WAL / checkpoints (enables replication + pgBackRest in later blocks) ---
+wal_level = replica
+max_wal_senders = 10
+max_replication_slots = 10
+wal_log_hints = on            # required by pg_rewind (Block 3)
+checkpoint_timeout = 15min
+max_wal_size = 4GB
+checkpoint_completion_target = 0.9
+
+#--- Planner (SSD) ---
+random_page_cost = 1.1
+effective_io_concurrency = 200
+
+#--- Logging (Block 4 troubleshooting) ---
+logging_collector = on
+log_directory = 'log'
+log_filename = 'postgresql-%a.log'
+log_line_prefix = '%m [%p] %h %u@%d '
+log_min_duration_statement = 250ms
+log_lock_waits = on
+log_checkpoints = on
+log_autovacuum_min_duration = 0
+
+#--- Stats / monitoring (pg_stat_monitor used in Block 4 / PMM QAN) ---
+shared_preload_libraries = 'pg_stat_statements,pg_stat_monitor'
+track_io_timing = on

--- a/roles/postgres/templates/percona-training.conf.j2
+++ b/roles/postgres/templates/percona-training.conf.j2
@@ -16,6 +16,7 @@ maintenance_work_mem = 512MB
 wal_level = replica
 max_wal_senders = 10
 max_replication_slots = 10
+wal_keep_size = 1GB           # retain recent WAL so pg_rewind + slotless standbys survive churn
 wal_log_hints = on            # required by pg_rewind (Block 3)
 checkpoint_timeout = 15min
 max_wal_size = 4GB

--- a/setup-class.sh
+++ b/setup-class.sh
@@ -80,6 +80,21 @@ fi
 echo "[3/4] Generating Ansible hosts file..."
 ./start-instances.php -a GETANSIBLEHOSTS -r "$REGION" -p "$CLIENT" > "ansible_hosts_$CLIENT"
 
+echo "[3.5/4] Waiting for SSH to come up on all instances..."
+# EC2 reports "running" ~30-60s before sshd accepts connections; without this wait
+# Ansible runs immediately and every host comes back UNREACHABLE.
+HOSTS=$(awk -F'ansible_ssh_host=' '/ansible_ssh_host=/ {split($2,a," "); print a[1]}' "ansible_hosts_$CLIENT")
+for h in $HOSTS; do
+    printf "  -- %s " "$h"
+    for i in $(seq 1 30); do
+        if ssh -i Percona-Training.key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+               -o ConnectTimeout=5 -o BatchMode=yes rocky@"$h" 'true' 2>/dev/null; then
+            echo "ready"; break
+        fi
+        printf "."; sleep 10
+    done
+done
+
 echo "[4/4] Provisioning with Ansible..."
 ansible-playbook -i "ansible_hosts_$CLIENT" hosts.yml
 

--- a/setup-class.sh
+++ b/setup-class.sh
@@ -57,9 +57,12 @@ echo "[1/4] Creating VPC..."
 ./setup-vpc.php -a ADD -r "$REGION" -p "$CLIENT"
 
 echo "[2/4] Launching Instances..."
-# For simplicity, we assume the user already knows the AMI or we pick a generic one. But normally we should fetch the latest.
-# Let's try to get the first AMI listed from start-instances.php.
-LATEST_AMI=$(./start-instances.php -a ADD -r "$REGION" -p dummy -c 1 -m db1 2>&1 | grep "AMI" | grep -v 'Name' | head -n 1 | awk '{print $NF}')
+# Fetch the latest Percona-Training AMI. start-instances.php in ADD mode without -i
+# prints the AMI list (sorted ascending by name/date) and exits, so we use that as the
+# lookup. We must take the LAST line ('tail -n 1' = newest AMI) — the banner line
+# "You must set the AMI (-i)..." also contains "AMI", so 'head -n 1' grabs that instead
+# and yields a non-AMI value.
+LATEST_AMI=$(./start-instances.php -a ADD -r "$REGION" -p dummy -c 1 -m db1 2>&1 | grep " - ami-" | grep -v 'Name' | tail -n 1 | awk '{print $NF}')
 
 if [[ "$LATEST_AMI" != ami-* ]]; then
     echo "Could not detect the latest AMI automatically. Please update setup-class.sh or pass an AMI manually."

--- a/setup-class.sh
+++ b/setup-class.sh
@@ -19,6 +19,7 @@ if [ -z "$CLASS_SLUG" ] || [ -z "$CLIENT" ] || [ -z "$TEAMS" ]; then
 fi
 
 MACHINE_TYPES=""
+NEEDS_PMM=""   # set to 1 for classes that use a shared PMM server (one per class)
 
 case "$CLASS_SLUG" in
     "mysql-ops")
@@ -40,7 +41,8 @@ case "$CLASS_SLUG" in
         MACHINE_TYPES="mongodb"
         ;;
     "pg-ops"|"pg-dev"|"pg-tutorial")
-        MACHINE_TYPES="db1"
+        MACHINE_TYPES="pg"      # alias → pg1,pg2,pg3 (one full set per team)
+        NEEDS_PMM=1             # plus one shared PMM server for the whole class
         ;;
     *)
         echo "Error: Unknown class slug: '$CLASS_SLUG'"
@@ -66,6 +68,11 @@ fi
 
 echo "Using AMI: $LATEST_AMI"
 ./start-instances.php -a ADD -r "$REGION" -p "$CLIENT" -c "$TEAMS" -m "$MACHINE_TYPES" -i "$LATEST_AMI"
+
+if [ "$NEEDS_PMM" = "1" ]; then
+    echo "Launching shared PMM server (one per class)..."
+    ./start-instances.php -a ADD -r "$REGION" -p "$CLIENT" -c 1 -m pmm -i "$LATEST_AMI"
+fi
 
 echo "[3/4] Generating Ansible hosts file..."
 ./start-instances.php -a GETANSIBLEHOSTS -r "$REGION" -p "$CLIENT" > "ansible_hosts_$CLIENT"

--- a/setup-vpc.php
+++ b/setup-vpc.php
@@ -769,6 +769,7 @@ function createSecurityGroups()
 		$haveInboundHTTPRule = false;
 		$haveInboundAltHTTPRule = false;
 		$haveInboundHTTPSRule = false;
+		$haveSelfReferenceRule = false;
 		
 		$res = $ec2->describeSecurityGroups(array(
 			'Filters' => array(
@@ -833,6 +834,21 @@ function createSecurityGroups()
 					printf("-- Found ingress rule for HTTPS (443).\n");
 					$haveInboundHTTPSRule = true;
 				}
+
+				// Self-reference (all traffic between instances in this SG).
+				// Covers intra-cluster ports for the multi-node labs.
+				if ($perm['IpProtocol'] == '-1'
+					&& isset($perm['UserIdGroupPairs']))
+				{
+					foreach($perm['UserIdGroupPairs'] as $pair)
+					{
+						if ($pair['GroupId'] == $config['SecurityGroup']['GroupId'])
+						{
+							printf("-- Found self-reference ingress rule (intra-cluster traffic).\n");
+							$haveSelfReferenceRule = true;
+						}
+					}
+				}
 			}
 		}
 		else
@@ -870,6 +886,13 @@ function createSecurityGroups()
 			printf("-- Did not find ingres rule for Alt-HTTP. Adding rule..\n");
 			addIngressRule(8080, "0.0.0.0/0");
 			printf("-- Added ingress rule for Alt-HTTP.\n");
+		}
+
+		if (!$haveSelfReferenceRule)
+		{
+			printf("-- Did not find self-reference rule. Adding rule (intra-cluster traffic)..\n");
+			addSelfReferenceRule();
+			printf("-- Added self-reference ingress rule (all traffic between training nodes).\n");
 		}
 	}
 	catch(Exception $e)
@@ -1042,7 +1065,31 @@ function addIngressRule($port, $cidr)
 				'ToPort' => $port,
 				'IpRanges' => array(array('CidrIp' => $cidr))
 			)
-		)		
+		)
+	));
+}
+
+function addSelfReferenceRule()
+{
+	global $ec2, $config;
+
+	/* Allow all traffic between instances in this security group. Every training
+	 * instance launches into this (the VPC default) SG, so this opens the
+	 * intra-cluster ports the multi-node labs need -- PXC/Galera, Group Replication,
+	 * and the PostgreSQL HA stack (5432, Patroni 8008, etcd 2379/2380, PgBouncer 6432,
+	 * HAProxy 5000/5001) -- without exposing anything to the internet.
+	*/
+	$res = $ec2->authorizeSecurityGroupIngress(array(
+		'DryRun' => DRY_RUN,
+		'GroupId' => $config['SecurityGroup']['GroupId'],
+		'IpPermissions' => array(
+			array(
+				'IpProtocol' => '-1',
+				'UserIdGroupPairs' => array(
+					array('GroupId' => $config['SecurityGroup']['GroupId'])
+				)
+			)
+		)
 	));
 }
 

--- a/start-instances.php
+++ b/start-instances.php
@@ -4,7 +4,7 @@
 include 'config.php';
 
 $actions      = array('ADD', 'DROP', 'LISTINSTANCES', 'GETANSIBLEHOSTS', 'GETCSV', 'GETSSHCONFIG', 'SYNCDYNAMO');
-$machineTypes = array('db1', 'db2', 'scoreboard', 'app', 'pmm', 'mysql1', 'mysql2', 'mysql3', 'pxc', 'gr', 'node1', 'node2', 'node3', 'node4', 'mongodb');
+$machineTypes = array('db1', 'db2', 'scoreboard', 'app', 'pmm', 'mysql1', 'mysql2', 'mysql3', 'pxc', 'gr', 'node1', 'node2', 'node3', 'node4', 'mongodb', 'pg1', 'pg2', 'pg3', 'pg');
 
 const DEBUG = false;
 
@@ -692,9 +692,9 @@ function parseOptions()
 		}
 
 		// Sanity; scoreboard and clusters cannot be launched with other types
-		if (count($machines) > 1 && (in_array("scoreboard", $machines) || in_array("pxc", $machines) || in_array("gr", $machines)))
+		if (count($machines) > 1 && (in_array("scoreboard", $machines) || in_array("pxc", $machines) || in_array("gr", $machines) || in_array("pg", $machines)))
 		{
-			printf("\nError: 'scoreboard', 'pxc', and 'gr' cannot be combined with other maching types.\n");
+			printf("\nError: 'scoreboard', 'pxc', 'gr', and 'pg' cannot be combined with other maching types.\n");
 			exit();
 		}
 
@@ -702,6 +702,12 @@ function parseOptions()
 		if ($machines[0] == 'pxc' || $machines[0] == 'gr')
 		{
 			$machines = array('mysql1', 'mysql2', 'mysql3', 'app');
+		}
+
+		// PostgreSQL course: the 'pg' alias expands to one full student set
+		if ($machines[0] == 'pg')
+		{
+			$machines = array('pg1', 'pg2', 'pg3');
 		}
 
 		// AMI is required for adding instance. Search and display a list of all Percona-Training* AMIs


### PR DESCRIPTION
## Summary

Adds AWS provisioning for the new **PostgreSQL DBA & Operations** course
(Percona Distribution for PostgreSQL 17, RHEL/EL9). Slides + labs live in
`pg-training/` in the `training-material` repo.

Per-student topology (mirrors the official Percona PG decks' `pg1/pg2/pg3` naming):

| Type | Role |
|------|------|
| `pg1` | Primary · sysbench client · first PMM-monitored node |
| `pg2` | Standby / promoted primary |
| `pg3` | pgBackRest repo · DR target · 3rd Patroni node · HAProxy + PgBouncer |
| `pmm` | **Shared** PMM Server 3 (one per class, like `scoreboard`) |

## What's included

- **`roles/postgres`** — installs PG17 from `ppg-17` + the Percona toolchain
  (pgBackRest, pg_stat_monitor, sysbench, chrony, pmm-client), runs `initdb`,
  drops in a lab-friendly `conf.d` config, adds a subnet `pg_hba` rule, and starts
  the service. `pg1` also gets the `replicator` + `sysbench` roles and the Bluebox
  dataset. **Cross-node name resolution is left to the existing `common` role** —
  `hosts.j2` already maps `pg1/pg2/pg3` to private IPs within each team, so this
  role does not touch `/etc/hosts`.
- **`hosts.yml`** — a `pg1:pg2:pg3` play (applies `postgres`) and a shared `pmm`
  play that runs PMM Server 3 in Docker.
- **`start-instances.php`** — registers `pg1`/`pg2`/`pg3` and the **`pg` alias**
  (expands to `pg1,pg2,pg3`, exactly like `pxc`/`gr`).
- **README** — documents the new machine types, the `pg` alias, and the
  security-group ports the replication/HA labs need.

## Usage

```bash
# one shared PMM server for the class, then one full pg set per student (e.g. 8)
./start-instances.php -a ADD -r us-west-2 -p ACME -c 1 -m pmm -i <ami>
./start-instances.php -a ADD -r us-west-2 -p ACME -c 8 -m pg  -i <ami>

./start-instances.php -a GETANSIBLEHOSTS -r us-west-2 -p ACME > ansible_hosts_acme
ansible-playbook -i ansible_hosts_acme hosts.yml -e pmm_server_ip=<pmm-private-ip>
```

## ⚠️ Security group prerequisite

The training VPC SG opens only 22/80/443/8080. The `pg` nodes additionally need
**intra-VPC** traffic on **5432** plus the HA-lab ports **8008** (Patroni),
**2379/2380** (etcd), **6432** (PgBouncer), **5000/5001** (HAProxy). Add a
self-referencing inbound rule (allow all from the SG to itself) before the
replication/HA labs. (Could be folded into `setup-vpc.php` in a follow-up.)

## Relationship to #28

Supersedes the container-on-one-host approach in #28. This uses **real
per-student multi-node EC2** so the replication, `pg_rewind`, pgBackRest
(remote repo over SSH), and Patroni HA labs are authentic. #28's container
model could return later as an optional lower-cost `pg-lab-single` type.

## Status / testing checklist (draft)

Marked **draft** — needs a validation run on a current Percona-Training AMI:

- [ ] Confirm exact package names on the AMI: `percona-pg-stat-monitor17`,
      `percona-pgbackrest`, `pmm-client` (role installs these best-effort).
- [ ] `ansible-playbook hosts.yml --limit pg1-T1` provisions cleanly; Bluebox loads.
- [ ] `pg1/pg2/pg3` resolve each other (via `common` `hosts.j2`).
- [ ] PMM play brings up PMM Server 3; `pg` nodes register with `-e pmm_server_ip=`.
- [ ] Add the SG self-reference rule and confirm cross-node 5432 connectivity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)