### PR TITLE
docs: fix markdownlint violations to get Quality Guard green

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,24 +5,31 @@ First off, thank you for considering contributing to the Percona Training AWS Sc
 ## How to Contribute
 
 ### Reporting Bugs
+
 If you find a bug, please create an issue on GitHub using the "Bug report" template. Include as much detail as possible to help us reproduce and fix it.
 
 ### Suggesting Enhancements
+
 We welcome ideas for new features or improvements. Please use the "Feature request" template to describe your idea and its benefits.
 
 ### Pull Requests
+
 We accept pull requests! To contribute code:
-1.  Fork the repository.
-2.  Create a new branch for your feature or fix.
-3.  Write your code and tests.
-4.  Run the linting and static analysis tools locally (`ansible-lint`, `phpstan`).
-5.  Submit a pull request to the `master` branch.
+
+1. Fork the repository.
+2. Create a new branch for your feature or fix.
+3. Write your code and tests.
+4. Run the linting and static analysis tools locally (`ansible-lint`, `phpstan`).
+5. Submit a pull request to the `master` branch.
 
 ## Code Style
+
 Please adhere to the existing code style in the repository. We use:
+
 - **PHP**: PHP 8.5+ with consistent indentation and PSR-like naming conventions.
 - **Ansible**: Roles and playbooks should be well-structured and linted.
 - **Packer**: Templates should be valid and follow best practices for AMIs.
 
 ## Community Health
+
 Please refer to the [CONTRIBUTORS.md](CONTRIBUTORS.md) for a list of the primary maintainers and contributors.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository provides tools for instructors to quickly launch, configure, and
 ## Prerequisites
 
 To run these scripts, your local control machine requires:
+
 * **PHP 8.5+**
 * **Composer** (for PHP dependencies)
 * **Ansible Core**
@@ -16,21 +17,25 @@ To run these scripts, your local control machine requires:
 ### Installation
 
 **macOS (Homebrew):**
+
 ```bash
 brew install php@8.5 ansible awscli composer make
 ```
 
 **Linux (Ubuntu/Debian):**
+
 ```bash
 sudo apt-get install php8.5 php-xml php-mbstring ansible awscli composer make
 ```
 
 **Linux (Rocky Linux/RHEL 9):**
+
 ```bash
 sudo dnf install php php-xml php-mbstring ansible-core awscli composer make
 ```
 
 After installing the system packages, install the PHP dependencies:
+
 ```bash
 composer install
 ```
@@ -49,7 +54,7 @@ The simplest setup is to run `aws configure` once, or export the environment var
 
 ## Setting Up a Training Environment
 
-The standard workflow utilizes a `Makefile` that encapsulates VPC creation, instance launching, and Ansible provisioning into a single command. 
+The standard workflow utilizes a `Makefile` that encapsulates VPC creation, instance launching, and Ansible provisioning into a single command.
 
 Environments are built based on **Class Slugs**. A slug represents the specific course being taught and automatically deploys the correct architecture (e.g., `db1`, `gr`, `pxc`).
 
@@ -108,6 +113,7 @@ make teardown client=TREK region=eu-west-1
 Use the following slugs with the `class=` parameter in your `make setup` command.
 
 ### MySQL Courses
+
 | Course Title | Class Slug | Architecture Deployed |
 | :--- | :--- | :--- |
 | MySQL Training for Database Operations Specialists | `mysql-ops` | `db1` (Source), `db2` (Replica) |
@@ -118,12 +124,14 @@ Use the following slugs with the `class=` parameter in your `make setup` command
 | Percona Group Replication Tutorial | `gr` | `gr` (3 nodes + 1 app) |
 
 ### MongoDB Courses
+
 | Course Title | Class Slug | Architecture Deployed |
 | :--- | :--- | :--- |
 | MongoDB Training for Database Operations Specialists | `mongo-ops` | `mongodb` |
 | MongoDB Training for Developers | `mongo-dev` | `mongodb` |
 
 ### PostgreSQL Courses
+
 | Course Title | Class Slug | Architecture Deployed |
 | :--- | :--- | :--- |
 | PostgreSQL Training for Database Operations Specialists | `pg-ops` | `db1` |
@@ -135,10 +143,10 @@ Use the following slugs with the `class=` parameter in your `make setup` command
 
 The provisioning scripts and Ansible playbooks support the following software and configurations:
 
-*   **Operating Systems:** Ubuntu 22.04+, Debian 11+, Rocky Linux 9+.
-*   **Database Versions:** Percona Server for MySQL 8.0, 8.4; Percona Server for MongoDB 7.0; and PMM 3.x client support.
-*   **Security:** IPTables is disabled by default to simplify lab networking.
-*   **SSL:** All MySQL instances are configured with SSL (SHA256).
+* **Operating Systems:** Ubuntu 22.04+, Debian 11+, Rocky Linux 9+.
+* **Database Versions:** Percona Server for MySQL 8.0, 8.4; Percona Server for MongoDB 7.0; and PMM 3.x client support.
+* **Security:** IPTables is disabled by default to simplify lab networking.
+* **SSL:** All MySQL instances are configured with SSL (SHA256).
 
 ---
 
@@ -147,20 +155,23 @@ The provisioning scripts and Ansible playbooks support the following software an
 For custom deployments or debugging, you can bypass the `Makefile` and use the underlying PHP scripts directly.
 
 ### VPC Management
+
 ```bash
 ./setup-vpc.php -a [ADD|DROP|LIST|REBUILD] -r [REGION] -p [CLIENT_SUFFIX]
 ```
 
 ### Instance Management
+
 ```bash
 ./start-instances.php -a ADD -r [REGION] -p [CLIENT_SUFFIX] -c [NUM_TEAMS] -m [MACHINE_TYPE] -i [AMI_ID]
 ```
 
-*   If you omit `-i [AMI_ID]`, the script will output a list of available `Percona-Training` AMIs in that region.
-*   To launch multiple machine types simultaneously, separate them with commas: `-m db1,db2`.
-*   Use `-o [OFFSET]` to add additional teams without overlapping existing numbers.
+* If you omit `-i [AMI_ID]`, the script will output a list of available `Percona-Training` AMIs in that region.
+* To launch multiple machine types simultaneously, separate them with commas: `-m db1,db2`.
+* Use `-o [OFFSET]` to add additional teams without overlapping existing numbers.
 
 ### CloudFormation Templates
+
 Older iterations of the training labs (PMM, some PXC/GR setups) utilized pure AWS CloudFormation. These templates are retained in the `cloudformations/` directory for legacy support and reference.
 
 ---
@@ -169,10 +180,10 @@ Older iterations of the training labs (PMM, some PXC/GR setups) utilized pure AW
 
 The scripts rely on an AWS DynamoDB table to sync and list the generated IPs for the student dashboard.
 
-*   **Region:** Must be in `us-east-1` (hardcoded).
-*   **Table Name:** `percona_training_servers`
-*   **Partition Key:** `teamTag` (String)
-*   **Sort Key:** `teamID` (Number)
+* **Region:** Must be in `us-east-1` (hardcoded).
+* **Table Name:** `percona_training_servers`
+* **Partition Key:** `teamTag` (String)
+* **Sort Key:** `teamID` (Number)
 
 *You generally do not need to manage this table. The scripts will create or update it automatically.*
 


### PR DESCRIPTION
The `markdown-lint` job in the new Quality Guard workflow (#33) fails on `main` with **37 errors** in `README.md` (25) and `CONTRIBUTING.md` (12). These are pre-existing formatting issues the linter now surfaces.

### Fix
Ran `markdownlint-cli2 --fix` (same version as CI: v0.12.1) against the two files. **Formatting only — no content changes:**

| Rule | What was fixed |
| --- | --- |
| MD030 list-marker-space | extra spaces after `1.` / `*` markers |
| MD022 blanks-around-headings | blank lines around headings |
| MD031 blanks-around-fences | blank lines around code fences |
| MD032 blanks-around-lists | blank lines around lists |
| MD009 no-trailing-spaces | trailing whitespace |

### Verification
Re-linting all root `*.md` with the CI's exact invocation now reports `Summary: 0 error(s)`, so the `markdown-lint` job will go green.

> Note: this PR is intentionally scoped to the markdown fix only. A separate follow-up will address the `ansible-lint` job (it currently runs with `|| true`, which is masking a real fatal YAML parse error in `roles/mysql/tasks/percona-repo.yml`).