### PR TITLE
ci: make ansible-lint gate (remove '|| true')

### DIFF
--- a/.github/workflows/quality-guard.yml
+++ b/.github/workflows/quality-guard.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install collections
         run: ansible-galaxy collection install community.general community.mysql
       - name: Run ansible-lint
-        run: ansible-lint hosts.yml roles/ || true
+        run: ansible-lint hosts.yml roles/
 
   markdown-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #59 · **depends on #63 — merge that first.**

The `ansible-lint` job ran with `ansible-lint hosts.yml roles/ || true`, so it always passed regardless of findings — a check that can't fail is decorative. This drops `|| true` so the job gates on genuine syntax/load errors. The existing `.ansible-lint` `warn_list` keeps the noisy stylistic rules non-blocking, so only real errors break the build.

### ⚠️ Merge order
This PR's `ansible-lint` check will be **red until #63 merges** — #63 fixes the malformed `percona-repo.yml` that the gate (correctly) trips on. Sequence:
1. Merge **#63** (the YAML fix) → `main` becomes lint-clean.
2. Rebase this PR onto `main` → `ansible-lint` goes green → merge.

(Previously this PR bundled both the fix and the gate; split per review so each PR does one thing.)