### PR TITLE
feat: make DynamoDB region configurable (default us-east-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,12 +180,17 @@ Older iterations of the training labs (PMM, some PXC/GR setups) utilized pure AW
 
 The scripts rely on an AWS DynamoDB table to sync and list the generated IPs for the student dashboard.
 
-* **Region:** Must be in `us-east-1` (hardcoded).
+* **Region:** `us-east-1` by default. Override with the `PERCONA_TRAINING_DYNAMODB_REGION` environment variable if the table lives elsewhere (this is independent of the EC2 training region passed via `-r`).
 * **Table Name:** `percona_training_servers`
 * **Partition Key:** `teamTag` (String)
 * **Sort Key:** `teamID` (Number)
 
 *You generally do not need to manage this table. The scripts will create or update it automatically.*
+
+```bash
+# Example: point the scripts at a DynamoDB table hosted in eu-west-1
+export PERCONA_TRAINING_DYNAMODB_REGION=eu-west-1
+```
 
 ---
 

--- a/dynamo.php
+++ b/dynamo.php
@@ -7,7 +7,7 @@ use Aws\DynamoDb\Exception\DynamoDbException;
 use Aws\DynamoDb\Marshaler;
 
 $dynamo = Aws\DynamoDb\DynamoDbClient::factory(array(
-    'region'  => 'us-east-1',
+    'region'  => getenv('PERCONA_TRAINING_DYNAMODB_REGION') ?: 'us-east-1',
     'version' => 'latest',
     'retries' => ['mode' => 'adaptive', 'max_attempts' => 10]));
 

--- a/start-instances.php
+++ b/start-instances.php
@@ -29,8 +29,12 @@ $ec2 = Aws\Ec2\Ec2Client::factory(array(
 use Aws\DynamoDb\Exception\DynamoDbException;
 use Aws\DynamoDb\Marshaler;
 
+// The DynamoDB table that backs the student dashboard lives in a single
+// region (us-east-1 by default). Override with PERCONA_TRAINING_DYNAMODB_REGION
+// if the table is hosted elsewhere. This is independent of the EC2 training
+// region passed via -r.
 $dynamo = Aws\DynamoDb\DynamoDbClient::factory(array(
-    'region'  => 'us-east-1',
+    'region'  => getenv('PERCONA_TRAINING_DYNAMODB_REGION') ?: 'us-east-1',
     'version' => 'latest',
     'retries' => ['mode' => 'adaptive', 'max_attempts' => 10]));
 


### PR DESCRIPTION
Closes #52

### Problem
The DynamoDB client region was hardcoded to `us-east-1` in `start-instances.php` and `dynamo.php`. If the `percona_training_servers` table is ever hosted in another region, the sync/list calls silently fail.

### Change
Region is now read from the `PERCONA_TRAINING_DYNAMODB_REGION` environment variable, **defaulting to `us-east-1`** so existing setups are unaffected:

```php
'region' => getenv('PERCONA_TRAINING_DYNAMODB_REGION') ?: 'us-east-1',
```

I chose an env var rather than a CLI flag deliberately: the DynamoDB table is a shared backend whose location is **independent of the EC2 training region** (`-r`). Folding it into `-r` would conflate the two. README's *DynamoDB Requirement* section documents the override.

### Verification
`php -l` passes on both files.

@utdrmac — flagging for your review since you've worked in this area (the credential refactor in #42 and the percona-repo work in #45). Open to a CLI-flag approach instead if you'd prefer; happy to adjust.