### PR TITLE
fix: correct malformed YAML in roles/mysql/tasks/percona-repo.yml

### DIFF
--- a/roles/mysql/tasks/percona-repo.yml
+++ b/roles/mysql/tasks/percona-repo.yml
@@ -6,14 +6,13 @@
     name:
       - http://repo.percona.com/yum/percona-release-latest.noarch.rpm
 
-  - name: Enable PS84, toolkit and PMM3 Repos
-    shell: >
-      percona-release setup ps-84-lts
-      percona-release enable pxb-84-lts && percona-release enable pmm3-client && percona-release enable pt
+- name: Enable PS84, toolkit and PMM3 Repos
+  shell: >
+    percona-release setup ps-84-lts
+    percona-release enable pxb-84-lts && percona-release enable pmm3-client && percona-release enable pt
 
-  - name: Install percona toolkit
-    dnf:
-      state: latest
-      name:
-        - percona-toolkit
-
+- name: Install percona toolkit
+  dnf:
+    state: latest
+    name:
+      - percona-toolkit


### PR DESCRIPTION
Refs #59 — **merge this first.**

`roles/mysql/tasks/percona-repo.yml` (added in #45) has over-indented list items, so `- name: Enable PS84…` and `- name: Install percona toolkit` nest inside the first task instead of being siblings. It fails a plain YAML parse (`did not find expected key`), which ansible-lint flags as a fatal `load-failure`.

This PR just **corrects the indentation** into a valid sibling task list — no behavioral change (the file is not currently included by the mysql role; whether to wire it in or remove it is the open question in #59).

This is split out from the ansible-lint gating change (#60) so the fix lands cleanly on its own; once this merges, #60 (removing `|| true`) will go green.