### PR TITLE
docs: deprecate legacy PLA19 launchers (stale hardcoded AMIs)

### DIFF
--- a/launch_pla19_pxc_tutorial.php
+++ b/launch_pla19_pxc_tutorial.php
@@ -1,6 +1,21 @@
 #!/usr/bin/env php72
 <?php
 
+/*
+ * DEPRECATED: one-off launcher for the legacy 2019 "PLA19" PXC tutorial.
+ * The hardcoded per-region $pxcAmis below are long stale and will not boot a
+ * current environment. Use the maintained workflow instead, which auto-detects
+ * the latest Percona-Training AMI:
+ *
+ *     make setup class=pxc client=<SUFFIX> teams=<N> region=<REGION>
+ *       -- or --
+ *     ./start-instances.php -a ADD -r <REGION> -p <SUFFIX> -c <N> -m pxc
+ *
+ * Retained for reference only.
+ */
+fwrite(STDERR, "WARNING: launch_pla19_pxc_tutorial.php is DEPRECATED and uses stale hardcoded AMIs.\n" .
+               "         Use 'make setup class=pxc ...' or './start-instances.php ... -m pxc' instead.\n");
+
 date_default_timezone_set('UTC');
 
 require 'aws.phar';

--- a/orc_tutorial_pla19.php
+++ b/orc_tutorial_pla19.php
@@ -1,6 +1,20 @@
 #!/usr/bin/env php72
 <?php
 
+/*
+ * DEPRECATED: one-off launcher for the legacy 2019 "PLA19" Orchestrator tutorial.
+ * The hardcoded per-region $pxcAmis below are long stale and will not boot a
+ * current environment. Use the maintained workflow instead, which auto-detects
+ * the latest Percona-Training AMI:
+ *
+ *     ./start-instances.php -a ADD -r <REGION> -p <SUFFIX> -c <N> -m db1,db2
+ *       (or `make setup ...` for a supported class slug)
+ *
+ * Retained for reference only.
+ */
+fwrite(STDERR, "WARNING: orc_tutorial_pla19.php is DEPRECATED and uses stale hardcoded AMIs.\n" .
+               "         Use './start-instances.php ...' or 'make setup ...' instead.\n");
+
 date_default_timezone_set('UTC');
 
 require 'aws.phar';


### PR DESCRIPTION
Closes #55

The one-off 2019 launchers `launch_pla19_pxc_tutorial.php` and `orc_tutorial_pla19.php` carry hardcoded per-region AMI IDs that are long stale and won't boot a current environment.

Rather than bake in fresh AMI IDs (which just go stale again — and the main flow already auto-detects the latest `Percona-Training` AMI), this adds a **deprecation header + a STDERR warning** to each, pointing users to the maintained workflow (`make setup` / `./start-instances.php`). The scripts are retained for reference.

No functional change to the supported workflow.