### PR TITLE
fix: make the Makefile class deploys actually work (+ e2e test matrix)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,49 @@
+# Training Environment Test Matrix
+
+End-to-end validation that every `make` class slug deploys and provisions on a
+current `Percona-Training` AMI, then tears down cleanly. Tracking issue: #65.
+
+## Method
+
+- **Region:** `us-west-2`, **teams=1** per architecture.
+- **Flow per slug:** `make setup` → (auto-detect newest AMI) → launch → wait for
+  SSH → `ansible-playbook hosts.yml` → verify recap → `make teardown`.
+- **AMI:** auto-detected newest — `Percona-Training-20260319` (`ami-019d664eea084aba9`).
+- **Date:** 2026-06-02.
+- Slugs are grouped by **distinct architecture** (many slugs share a machine set),
+  so each shape is exercised once.
+
+## Results — L1 (deploys + provisions clean, then tears down)
+
+| Architecture | Slug(s) covered | Result | Ansible recap (failed=0 everywhere) |
+| --- | --- | --- | --- |
+| `db1` | `mysql-dev`, `mysql-101`, `mysql-oracle-dba`, `proxysql`, `pg-ops`, `pg-dev`, `pg-tutorial` | ✅ PASS | db1 ok=9 |
+| `db1` + `db2` | `mysql-ops` | ✅ PASS | db1 ok=9, db2 ok=10 |
+| `node1` | `mysql-k8s` | ✅ PASS | node1 ok=15 |
+| `pxc` (app+mysql1/2/3) | `pxc` | ✅ PASS | app=11, mysql1=16, mysql2=12, mysql3=12 |
+| `gr` (app+mysql1/2/3) | `gr`, `gr-101` | ✅ PASS | app=11, mysql1=16, mysql2=12, mysql3=12 |
+| `mongodb` | `mongo-ops`, `mongo-dev` | ✅ PASS | mongodb ok=14 |
+
+All teardowns verified: **0 instances / 0 VPCs** left after the run.
+
+## Bugs found and fixed (this PR)
+
+1. **`make list-amis` errored** — it invoked a `LISTAMIS` action that did not
+   exist. Added a real `LISTAMIS` action (region-only).
+2. **`make setup` never launched** — AMI auto-detection ran
+   `grep "AMI" | grep -v 'Name' | head -n 1`, which matched the prose line
+   *"You must set the AMI (-i)..."* and returned the word `instances.`, failing
+   the `ami-*` check every time. Switched to `LISTAMIS | grep -oE 'ami-…' | tail -1`.
+3. **`make setup` ran Ansible too early and hid failures** — no wait for sshd
+   (Ansible `UNREACHABLE`), and the script reported "Setup complete!" / exit 0
+   even when Ansible failed. Added a per-host SSH-readiness poll and exit-code
+   propagation.
+
+## Notes / follow-ups
+
+- `pg-ops` / `pg-dev` / `pg-tutorial` currently map to the **MySQL `db1`** machine
+  type (not PostgreSQL). The real PostgreSQL topology (`pg1/pg2/pg3`) is in #51.
+- `make teardown` prompts for interactive `y/n` confirmation (a safety guard);
+  for automation pipe `yes |`.
+- DynamoDB region configurability (#52/#61) and the `TAG` action (#53/#62) are
+  validated under their own PRs.

--- a/setup-class.sh
+++ b/setup-class.sh
@@ -55,9 +55,9 @@ echo "[1/4] Creating VPC..."
 ./setup-vpc.php -a ADD -r "$REGION" -p "$CLIENT"
 
 echo "[2/4] Launching Instances..."
-# For simplicity, we assume the user already knows the AMI or we pick a generic one. But normally we should fetch the latest.
-# Let's try to get the first AMI listed from start-instances.php.
-LATEST_AMI=$(./start-instances.php -a ADD -r "$REGION" -p dummy -c 1 -m db1 2>&1 | grep "AMI" | grep -v 'Name' | head -n 1 | awk '{print $NF}')
+# Auto-detect the newest Percona-Training AMI in the region. LISTAMIS prints the
+# AMIs sorted oldest->newest, so the last ami-* id is the latest one.
+LATEST_AMI=$(./start-instances.php -a LISTAMIS -r "$REGION" 2>&1 | grep -oE 'ami-[0-9a-f]+' | tail -n 1)
 
 if [[ "$LATEST_AMI" != ami-* ]]; then
     echo "Could not detect the latest AMI automatically. Please update setup-class.sh or pass an AMI manually."

--- a/setup-class.sh
+++ b/setup-class.sh
@@ -70,7 +70,33 @@ echo "Using AMI: $LATEST_AMI"
 echo "[3/4] Generating Ansible hosts file..."
 ./start-instances.php -a GETANSIBLEHOSTS -r "$REGION" -p "$CLIENT" > "ansible_hosts_$CLIENT"
 
+# EC2 reports an instance as 'running' 30-90s before sshd actually accepts
+# connections, so running Ansible immediately fails with UNREACHABLE. Wait for
+# SSH on every host (up to 5 min each) before provisioning.
+echo "[3.5/4] Waiting for SSH to be ready on all instances..."
+HOSTS=$(grep -oE 'ansible_ssh_host=[^[:space:]]+' "ansible_hosts_$CLIENT" | cut -d= -f2 | sort -u)
+for h in $HOSTS; do
+    printf "  -- %s " "$h"
+    ready=0
+    for i in $(seq 1 30); do
+        if ssh -i Percona-Training.key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+               -o ConnectTimeout=5 -o BatchMode=yes "rocky@$h" 'true' 2>/dev/null; then
+            echo "ready"; ready=1; break
+        fi
+        printf "."; sleep 10
+    done
+    if [ "$ready" -ne 1 ]; then
+        echo " TIMED OUT"
+        echo "Error: $h never became reachable over SSH (5 min). Aborting before provisioning."
+        exit 1
+    fi
+done
+
 echo "[4/4] Provisioning with Ansible..."
-ansible-playbook -i "ansible_hosts_$CLIENT" hosts.yml
+if ! ansible-playbook -i "ansible_hosts_$CLIENT" hosts.yml; then
+    echo "Error: Ansible provisioning FAILED. Instances are running but not fully configured."
+    echo "       Re-run: ansible-playbook -i ansible_hosts_$CLIENT hosts.yml"
+    exit 1
+fi
 
 echo "Setup complete! Run 'make summary client=$CLIENT' to get the class handout."

--- a/start-instances.php
+++ b/start-instances.php
@@ -3,12 +3,21 @@
 
 include 'config.php';
 
-$actions      = array('ADD', 'DROP', 'LISTINSTANCES', 'GETANSIBLEHOSTS', 'GETCSV', 'GETSSHCONFIG', 'SYNCDYNAMO');
+$actions      = array('ADD', 'DROP', 'LISTINSTANCES', 'GETANSIBLEHOSTS', 'GETCSV', 'GETSSHCONFIG', 'SYNCDYNAMO', 'LISTAMIS');
 $machineTypes = array('db1', 'db2', 'scoreboard', 'app', 'pmm', 'mysql1', 'mysql2', 'mysql3', 'pxc', 'gr', 'node1', 'node2', 'node3', 'node4', 'mongodb');
 
 const DEBUG = false;
 
 $options = parseOptions();
+
+// LISTAMIS only needs a region: list the Percona-Training AMIs and exit before
+// we try to load any per-client VPC config (which requires a suffix).
+if ($options['action'] == 'LISTAMIS')
+{
+	printAmis($options['region']);
+	exit();
+}
+
 $config = loadConfig();
 
 /* This is the EC2 API Client object */
@@ -659,8 +668,8 @@ function parseOptions()
 		exit();
 	}
 
-	// Suffix is required
-	if (!isset($_opt['suffix']) || strlen($_opt['suffix']) < 3)
+	// Suffix is required (except LISTAMIS, which only needs a region)
+	if ($_opt['action'] != 'LISTAMIS' && (!isset($_opt['suffix']) || strlen($_opt['suffix']) < 3))
 	{
 		printf("\nError: -p is required. 3 character minimum.\n");
 		exit();


### PR DESCRIPTION
Closes #65

End-to-end validation of every `make` class slug against a current `Percona-Training` AMI (us-west-2, teams=1, full `make setup` → provision → `make teardown`). It surfaced **three real breakages** — including that `make setup` could not launch *anything* — all fixed here.

### Bugs fixed
1. **`make list-amis` errored** — it called a `LISTAMIS` action that didn't exist. Added a real `LISTAMIS` action (region-only, no suffix/VPC config needed).
2. **`make setup` never launched an instance.** AMI auto-detection ran `grep "AMI" | grep -v 'Name' | head -n 1`, which matched the prose line *"You must set the AMI (-i)..."* and returned the literal word `instances.` — never an `ami-*` — so every `make setup` died with *"Could not detect the latest AMI."* Switched to `LISTAMIS | grep -oE 'ami-[0-9a-f]+' | tail -1` (robustly picks the newest).
3. **`make setup` ran Ansible too early and hid failures.** No wait for sshd → Ansible `UNREACHABLE`; and it printed "Setup complete!" / exit 0 even when Ansible failed. Added a per-host SSH-readiness poll (parsing `ansible_ssh_host` robustly — stops at tabs, which `mysql2/3` lines add via `mysql_master_host=`) and exit-code propagation.

### Test results (all `failed=0`, all torn down — 0 instances/VPCs left)

| Architecture | Slugs covered | Result |
| --- | --- | --- |
| `db1` | mysql-dev, mysql-101, mysql-oracle-dba, proxysql, pg-ops, pg-dev, pg-tutorial | ✅ ok=9 |
| `db1`+`db2` | mysql-ops | ✅ db1=9, db2=10 |
| `node1` | mysql-k8s | ✅ ok=15 |
| `pxc` | pxc | ✅ app=11, mysql1=16, mysql2/3=12 |
| `gr` | gr, gr-101 | ✅ app=11, mysql1=16, mysql2/3=12 |
| `mongodb` | mongo-ops, mongo-dev | ✅ ok=14 |

Details recorded in `TESTING.md`.

### Notes
- `pg-ops`/`pg-dev`/`pg-tutorial` still map to the **MySQL `db1`** machine on `main` (not PostgreSQL); the real PG topology is in #51 — flagged in `TESTING.md` and #65.
- `make teardown` prompts `y/n` (intentional safety); pipe `yes |` for automation.