### PR TITLE
feat: enable adaptive retries on all AWS SDK clients

### DIFF
--- a/dynamo.php
+++ b/dynamo.php
@@ -8,7 +8,8 @@ use Aws\DynamoDb\Marshaler;
 
 $dynamo = Aws\DynamoDb\DynamoDbClient::factory(array(
     'region'  => 'us-east-1',
-    'version' => 'latest'));
+    'version' => 'latest',
+    'retries' => ['mode' => 'adaptive', 'max_attempts' => 10]));
 
 $i = array("machineType" => "mysql1", "PublicIp" => "33.33.33.33", "PrivateIp" => "1.2.3.4");
 

--- a/setup-vpc.php
+++ b/setup-vpc.php
@@ -22,6 +22,7 @@ $subnet_map = array(
 $ec2 = new Ec2Client([
 	'region' => $config['Region'] ?? $options['region'],
 	'version'=> 'latest',
+	'retries'=> ['mode' => 'adaptive', 'max_attempts' => 10],
 ]);
 
 switch($options['action'])

--- a/start-instances.php
+++ b/start-instances.php
@@ -23,14 +23,16 @@ $config = loadConfig();
 /* This is the EC2 API Client object */
 $ec2 = Aws\Ec2\Ec2Client::factory(array(
 	'region' => $options['region'],
-	'version'=> 'latest'));
+	'version'=> 'latest',
+	'retries'=> ['mode' => 'adaptive', 'max_attempts' => 10]));
 
 use Aws\DynamoDb\Exception\DynamoDbException;
 use Aws\DynamoDb\Marshaler;
 
 $dynamo = Aws\DynamoDb\DynamoDbClient::factory(array(
     'region'  => 'us-east-1',
-    'version' => 'latest'));
+    'version' => 'latest',
+    'retries' => ['mode' => 'adaptive', 'max_attempts' => 10]));
 
 switch($options['action'])
 {
@@ -801,7 +803,8 @@ function printAmis($region)
 {
 	$ec2 = Aws\Ec2\Ec2Client::factory(array(
 		'region' => $region,
-		'version'=> 'latest'));
+		'version'=> 'latest',
+		'retries'=> ['mode' => 'adaptive', 'max_attempts' => 10]));
 
 	$res = $ec2->describeImages(array(
 		'Owners' => array('self'),


### PR DESCRIPTION
Closes #54

AWS API calls had no explicit retry/backoff configuration, so transient throttling (`RequestLimitExceeded`) or network blips could abort a run mid-provision and leave a half-built environment.

Sets `'retries' => ['mode' => 'adaptive', 'max_attempts' => 10]` on **every** EC2 and DynamoDB client:
- `start-instances.php` (main `$ec2`, `$dynamo`, and the `printAmis` `$ec2`)
- `setup-vpc.php` (`$ec2`)
- `dynamo.php` (`$dynamo`)

**Adaptive** mode adds client-side rate limiting, which suits the bursty `runInstances`/`describeInstances` calls when launching many teams at once.

### Verification
- `php -l` clean on all three files.
- Confirmed the SDK accepts the config and a live `LISTAMIS` call works.

> Note: this touches the same client-factory blocks as #61 (DynamoDB region). They're additive (different keys in the same array), but whichever merges first will leave the other a trivial rebase.