### PR TITLE
fix: guard destructive replication/teardown Ansible tasks against re-runs

### DIFF
--- a/hosts.yml
+++ b/hosts.yml
@@ -196,6 +196,10 @@
     - mysql
   tasks:
 
+  # Guarded with `creates`: this resets replication, so it must run only on
+  # the initial provision. Re-running the playbook on an already-configured
+  # node (e.g. `--limit`, or after a partial failure) skips it instead of
+  # tearing down a working replica.
   - name: Connect Async Replication
     tags: connect_replication
     shell: >
@@ -203,7 +207,13 @@
       CHANGE REPLICATION SOURCE TO SOURCE_HOST='{{ hostvars[inventory_hostname]['mysql_master_host'] }}',
       SOURCE_USER='repl', SOURCE_PASSWORD='R3plica1234#',
       SOURCE_LOG_FILE='mysqld-bin.000001', SOURCE_LOG_POS=4, SOURCE_SSL=1; START REPLICA;"
+      && touch /var/lib/mysql/.training_async_repl_done
+    args:
+      creates: /var/lib/mysql/.training_async_repl_done
 
+  # Guarded with `creates`: this DROPs the lab databases. Without the guard a
+  # re-run would wipe imdb/world/sakila/sysbench (and any student work in them).
+  # Runs once on initial provision; skipped on re-runs.
   - name: GROUP REPLICATION - Drop everything, reset binary logs
     shell: >
       mysql -uroot -e "STOP REPLICA; RESET REPLICA ALL;
@@ -213,6 +223,9 @@
       DROP DATABASE IF EXISTS sysbench;
       FLUSH BINARY LOGS;
       RESET BINARY LOGS AND GTIDS;"
+      && touch /var/lib/mysql/.training_gr_reset_done
+    args:
+      creates: /var/lib/mysql/.training_gr_reset_done
     when: gr is defined and gr == "Y" and 'mysql3' in inventory_hostname
 
 # For MongoDB exercises


### PR DESCRIPTION
Closes #56 (scoped — see note)

The `mysql2`/`mysql3` provisioning tasks reset replication and **DROP the lab databases** (`imdb`/`world`/`sakila`/`sysbench`) via raw `shell`, with no idempotency guard. The README tells instructors they can re-run the playbook (and the `--limit` flow re-provisions a single node) — but re-running these on an already-configured node would **tear down a working replica or wipe student data**.

### Change
Add `creates:` sentinel guards so each runs **once** at initial provision and is skipped on re-runs:
- `Connect Async Replication` → `/var/lib/mysql/.training_async_repl_done`
- `GROUP REPLICATION - Drop everything…` → `/var/lib/mysql/.training_gr_reset_done`

(The marker is only written after the `mysql` command succeeds, so a failed run safely retries. `db2`'s package removal is already guarded by its `existing_setup` stat check.)

### Scope note
Deliberately scoped to **guarding the destructive tasks** rather than a full idempotency refactor of `hosts.yml` — the training instances are ephemeral, so the high-value win is "a re-run never wipes data," not rewriting every shell task. The broader refactor can remain a someday-maybe.

### Verification
`ansible-lint hosts.yml roles/` → `Passed: 0 failure(s)`; YAML parses clean.