### PR TITLE
fix: PXC tutorial installs PXC 8.4 to match the 8.4 base AMI

### DIFF
--- a/migrate_async_to_pxc.yml
+++ b/migrate_async_to_pxc.yml
@@ -23,7 +23,7 @@
      
   - name: Enable Percona XtraDB Cluster Repo
     shell: >
-      percona-release enable pxc-80
+      percona-release enable pxc-84-lts
 
   - name: Install Percona XtraDB Cluster
     yum:


### PR DESCRIPTION
Closes #20

### Root cause (validated live)
`migrate_async_to_pxc.yml` enabled `pxc-80` and installed **PXC 8.0.45**, but the base AMI is now **Percona Server 8.4.7**. PXC 8.0's mysqld refuses to start on an 8.4 datadir:

```
[ERROR] [MY-014061] [InnoDB] Invalid MySQL server downgrade:
        Cannot downgrade from 80407 to 80045. Downgrade is only permitted between patch releases.
[ERROR] [Server] Data Dictionary initialization failed.  [Server] Aborting
```

So `systemctl start mysql@bootstrap` crashed on mysql1 and the cluster never formed — mysql2/mysql3 never even reached SST. **This is the current cause of #20.** The issue's *original* cause (the `early-plugin-load = keyring_file.so` keyring) is already gone — the AMI uses the component keyring, which initializes fine (`Keyring component initialized successfully`).

### Fix
One line: `percona-release enable pxc-80` → `pxc-84-lts`, so PXC matches the PS 8.4 datadir.

### Verified end-to-end (us-west-2, full lab path)
`make setup class=pxc` → `ansible-playbook migrate_async_to_pxc.yml`:

| Before (`pxc-80`) | After (`pxc-84-lts`) |
|---|---|
| bootstrap mysql1 crashes (downgrade error) | playbook completes, `failed=0` |
| no cluster | `percona-xtradb-cluster-server-8.4.8` installed |
| mysql2/3 never SST | **mysql2/mysql3 complete SST** |
| — | `wsrep_cluster_size=3`, `status=Primary`, `state=Synced` |

Teardown verified clean afterward.